### PR TITLE
build(deps): update Pocket IC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
       - name: 'Install PocketIC server'
         uses: dfinity/pocketic@main
         with:
-          pocket-ic-server-version: "7.0.0"
+          pocket-ic-server-version: "8.0.0"
 
       - name: Cargo test
         run: cargo test --package sol_rpc_int_tests -- --test-threads 2 --nocapture

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,6 +101,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
+name = "backoff"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+dependencies = [
+ "getrandom 0.2.15",
+ "instant",
+ "rand 0.8.5",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1000,6 +1011,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
+name = "flate2"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11faaf5a5236997af9848be0bef4db95824b1d534ebc64d0f0c6cf3e67bd38dc"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1358,9 +1379,9 @@ dependencies = [
 
 [[package]]
 name = "ic-certification"
-version = "2.6.0"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e64ee3d8b6e81b51f245716d3e0badb63c283c00f3c9fb5d5219afc30b5bf821"
+checksum = "ffb40d73f9f8273dc6569a68859003bbd467c9dc6d53c6fd7d174742f857209d"
 dependencies = [
  "hex",
  "serde",
@@ -1403,9 +1424,9 @@ dependencies = [
 
 [[package]]
 name = "ic-transport-types"
-version = "0.37.1"
+version = "0.39.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875dc4704780383112e8e8b5063a1b98de114321d0c7d3e7f635dcf360a57fba"
+checksum = "979ee7bee5a67150a4c090fb012c93c294a528b4a867bad9a15cc6d01cb4227f"
 dependencies = [
  "candid",
  "hex",
@@ -1413,9 +1434,10 @@ dependencies = [
  "leb128",
  "serde",
  "serde_bytes",
+ "serde_cbor",
  "serde_repr",
  "sha2 0.10.8",
- "thiserror 1.0.69",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -1591,6 +1613,15 @@ checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -2130,12 +2161,14 @@ dependencies = [
 
 [[package]]
 name = "pocket-ic"
-version = "6.0.0"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "124a2380ca6f557adf8b02517cbfd2f564113230e14cda6f6aadd3dfe156293c"
+checksum = "ccd672d6b262731dccae40cb561e4c578709ea9987fbf649377d51077bf16db3"
 dependencies = [
+ "backoff",
  "base64 0.13.1",
  "candid",
+ "flate2",
  "hex",
  "ic-certification",
  "ic-transport-types",
@@ -2149,7 +2182,7 @@ dependencies = [
  "slog",
  "strum 0.26.3",
  "strum_macros 0.26.4",
- "thiserror 1.0.69",
+ "thiserror 2.0.11",
  "tokio",
  "tracing",
  "tracing-appender",
@@ -4267,6 +4300,7 @@ dependencies = [
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "time",
  "tracing",
  "tracing-core",
  "tracing-log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ ic-cdk = "0.17.1"
 ic-ed25519 = "0.1.0"
 ic-stable-structures = "0.6.7"
 ic-test-utilities-load-wasm = { git = "https://github.com/dfinity/ic", tag = "release-2025-01-23_03-04-base" }
-pocket-ic = "6.0.0"
+pocket-ic = "7.0.0"
 proptest = "1.6.0"
 regex = "1.11.1"
 serde = { version = "1.0.219", features = ["derive"] }

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -4,7 +4,7 @@ use candid::{decode_args, encode_args, CandidType, Encode, Principal};
 use canlog::{Log, LogEntry};
 use ic_cdk::api::call::RejectionCode;
 use pocket_ic::management_canister::{CanisterId, CanisterSettings};
-use pocket_ic::{nonblocking::PocketIc, PocketIcBuilder, UserError, WasmResult};
+use pocket_ic::{nonblocking::PocketIc, PocketIcBuilder, RejectCode, RejectResponse};
 use serde::de::DeserializeOwned;
 use sol_rpc_canister::{
     http_types::{HttpRequest, HttpResponse},
@@ -161,13 +161,13 @@ impl PocketIcRuntime<'_> {
     }
 
     fn decode_call_result<Out>(
-        result: Result<WasmResult, UserError>,
+        result: Result<Vec<u8>, RejectResponse>,
     ) -> Result<Out, (RejectionCode, String)>
     where
         Out: CandidType + DeserializeOwned + 'static,
     {
         match result {
-            Ok(WasmResult::Reply(bytes)) => decode_args(&bytes).map(|(res,)| res).map_err(|e| {
+            Ok(bytes) => decode_args(&bytes).map(|(res,)| res).map_err(|e| {
                 (
                     RejectionCode::CanisterError,
                     format!(
@@ -177,17 +177,16 @@ impl PocketIcRuntime<'_> {
                     ),
                 )
             }),
-            Ok(WasmResult::Reject(s)) => Err((RejectionCode::CanisterReject, s)),
             Err(e) => {
-                let rejection_code = match e.code as u64 {
-                    100..=199 => RejectionCode::SysFatal,
-                    200..=299 => RejectionCode::SysTransient,
-                    300..=399 => RejectionCode::DestinationInvalid,
-                    400..=499 => RejectionCode::CanisterReject,
-                    500..=599 => RejectionCode::CanisterError,
-                    _ => RejectionCode::Unknown,
+                let rejection_code = match e.reject_code {
+                    RejectCode::SysFatal => RejectionCode::SysFatal,
+                    RejectCode::SysTransient => RejectionCode::SysTransient,
+                    RejectCode::DestinationInvalid => RejectionCode::DestinationInvalid,
+                    RejectCode::CanisterReject => RejectionCode::CanisterReject,
+                    RejectCode::CanisterError => RejectionCode::CanisterError,
+                    RejectCode::SysUnknown => RejectionCode::Unknown,
                 };
-                Err((rejection_code, e.description))
+                Err((rejection_code, e.reject_message))
             }
         }
     }


### PR DESCRIPTION
Update Pocket IC to the latest version: client to [v7](https://github.com/dfinity/ic/blob/1c22acdd5dc07b7979ee8b7b4b3bb9992c178783/packages/pocket-ic/CHANGELOG.md?plain=1#L15) and server to [v8](https://github.com/dfinity/pocketic/releases/tag/8.0.0). 

The code changes are due to the following breaking changes:
> The response types `pocket_ic::WasmResult`, `pocket_ic::UserError`, and `pocket_ic::CallError` are replaced by a single reject response type `pocket_ic::RejectResponse`.