### PR TITLE
fix: API keys

### DIFF
--- a/canister/scripts/provision.sh
+++ b/canister/scripts/provision.sh
@@ -8,6 +8,8 @@ set -u # or set -o nounset
 : "$ALCHEMY_MAINNET_API_KEY"
 : "$ALCHEMY_DEVNET_API_KEY"
 : "$ANKR_MAINNET_API_KEY"
+: "$DRPC_DEVNET_API_KEY"
+: "$DRPC_MAINNET_API_KEY"
 : "$ANKR_DEVNET_API_KEY"
 : "$HELIUS_MAINNET_API_KEY"
 : "$HELIUS_DEVNET_API_KEY"
@@ -23,6 +25,8 @@ dfx canister call ${CANISTER} updateApiKeys "(vec {
   record { variant { AlchemyDevnet }; opt \"${ALCHEMY_DEVNET_API_KEY}\" };
   record { variant { AnkrMainnet }; opt \"${ANKR_MAINNET_API_KEY}\" };
   record { variant { AnkrDevnet }; opt \"${ANKR_DEVNET_API_KEY}\" };
+  record { variant { DrpcMainnet }; opt \"${DRPC_MAINNET_API_KEY}\" };
+  record { variant { DrpcDevnet }; opt \"${DRPC_DEVNET_API_KEY}\" };
   record { variant { HeliusMainnet }; opt \"${HELIUS_MAINNET_API_KEY}\" };
   record { variant { HeliusDevnet }; opt \"${HELIUS_DEVNET_API_KEY}\" };
 })" ${FLAGS}

--- a/canister/src/providers/mod.rs
+++ b/canister/src/providers/mod.rs
@@ -70,7 +70,7 @@ thread_local! {
             cluster: SolanaCluster::Mainnet,
             access: RpcAccess::Authenticated {
                 auth: RpcAuth::UrlParameter {
-                    url_pattern: "https://devnet.helius-rpc.com/?api-key={API_KEY}".to_string(),
+                    url_pattern: "https://mainnet.helius-rpc.com/?api-key={API_KEY}".to_string(),
                 },
                 public_url: None,
             },
@@ -79,7 +79,7 @@ thread_local! {
             cluster: SolanaCluster::Devnet,
             access: RpcAccess::Authenticated {
                 auth: RpcAuth::UrlParameter {
-                    url_pattern: "https://mainnet.helius-rpc.com/?api-key={API_KEY}".to_string(),
+                    url_pattern: "https://devnet.helius-rpc.com/?api-key={API_KEY}".to_string(),
                 },
                 public_url: None,
             },

--- a/canister/src/providers/mod.rs
+++ b/canister/src/providers/mod.rs
@@ -50,15 +50,21 @@ thread_local! {
         },
         SupportedRpcProviderId::DrpcMainnet => SupportedRpcProvider {
             cluster: SolanaCluster::Mainnet,
-            access: RpcAccess::Unauthenticated {
-                public_url: "https://solana.drpc.org".to_string(),
-            },
+            access: RpcAccess::Authenticated {
+            auth: RpcAuth::UrlParameter {
+                    url_pattern: "https://lb.drpc.org/ogrpc?network=solana&dkey={API_KEY}".to_string()
+                },
+                public_url: Some("https://solana.drpc.org".to_string()),
+            }
         },
         SupportedRpcProviderId::DrpcDevnet => SupportedRpcProvider {
             cluster: SolanaCluster::Devnet,
-            access: RpcAccess::Unauthenticated {
-                public_url: "https://solana-devnet.drpc.org".to_string(),
-            },
+            access: RpcAccess::Authenticated {
+            auth: RpcAuth::UrlParameter {
+                    url_pattern: "https://lb.drpc.org/ogrpc?network=solana-devnet&dkey={API_KEY}".to_string()
+                },
+                public_url: Some("https://solana-devnet.drpc.org".to_string()),
+            }
         },
         SupportedRpcProviderId::HeliusMainnet => SupportedRpcProvider {
             cluster: SolanaCluster::Mainnet,

--- a/canister/src/providers/mod.rs
+++ b/canister/src/providers/mod.rs
@@ -110,21 +110,21 @@ impl Providers {
     // if the providers are not explicitly specified by the caller.
     const DEFAULT_MAINNET_SUPPORTED_PROVIDERS: &'static [SupportedRpcProviderId] = &[
         SupportedRpcProviderId::AlchemyMainnet,
-        SupportedRpcProviderId::AnkrMainnet,
+        SupportedRpcProviderId::HeliusMainnet,
         SupportedRpcProviderId::DrpcMainnet,
     ];
     const NON_DEFAULT_MAINNET_SUPPORTED_PROVIDERS: &'static [SupportedRpcProviderId] = &[
-        SupportedRpcProviderId::HeliusMainnet,
+        SupportedRpcProviderId::AnkrMainnet,
         SupportedRpcProviderId::PublicNodeMainnet,
     ];
 
     const DEFAULT_DEVNET_SUPPORTED_PROVIDERS: &'static [SupportedRpcProviderId] = &[
         SupportedRpcProviderId::AlchemyDevnet,
-        SupportedRpcProviderId::AnkrDevnet,
+        SupportedRpcProviderId::HeliusDevnet,
         SupportedRpcProviderId::DrpcDevnet,
     ];
     const NON_DEFAULT_DEVNET_SUPPORTED_PROVIDERS: &'static [SupportedRpcProviderId] =
-        &[SupportedRpcProviderId::HeliusDevnet];
+        &[SupportedRpcProviderId::AnkrDevnet];
 
     pub fn new(source: RpcSources, strategy: ConsensusStrategy) -> Result<Self, ProviderError> {
         fn get_sources(provider_ids: &[SupportedRpcProviderId]) -> Vec<RpcSource> {


### PR DESCRIPTION
1. Modify the `dRPC` provider to support API keys
2. Switch Ankr for Helius as default provider, since Ankr limits the total number of API keys that can be used to 3, meaning that currently we have a single API key for Solana (2 are for the EVM RPC canister for prod/staging)
3. Fix URL for Helius: the URL for mainnet and devnet was switched.