### PR TITLE
refactor: use method from JSON-RPC request for metric

### DIFF
--- a/canister/src/candid_rpc/mod.rs
+++ b/canister/src/candid_rpc/mod.rs
@@ -11,7 +11,7 @@ use sol_rpc_types::{
 };
 use std::fmt::Debug;
 
-pub async fn process_request<Params, Output, Error>(
+pub async fn send_multi<Params, Output, Error>(
     request: Result<MultiRpcRequest<Params, Output>, Error>,
 ) -> MultiRpcResult<Output>
 where

--- a/canister/src/candid_rpc/mod.rs
+++ b/canister/src/candid_rpc/mod.rs
@@ -1,26 +1,52 @@
+use crate::metrics::MetricRpcMethod;
+use crate::rpc_client::MultiRpcRequest;
 use crate::{
-    add_metric_entry, metrics::RpcMethod, providers::get_provider, rpc_client::ReducedResult,
-    util::hostname_from_url,
+    add_metric_entry, providers::get_provider, rpc_client::ReducedResult, util::hostname_from_url,
 };
 use canhttp::multi::ReductionError;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
 use sol_rpc_types::{
     MultiRpcResult, RpcAccess, RpcAuth, RpcError, RpcSource, SupportedRpcProvider,
 };
+use std::fmt::Debug;
 
-pub fn process_result<T>(method: RpcMethod, result: ReducedResult<T>) -> MultiRpcResult<T> {
+pub async fn process_request<Params, Output, Error>(
+    request: Result<MultiRpcRequest<Params, Output>, Error>,
+) -> MultiRpcResult<Output>
+where
+    Params: Serialize + Clone + Debug,
+    Output: Debug + DeserializeOwned + PartialEq + Serialize,
+    Error: Into<RpcError>,
+{
+    match request {
+        Ok(request) => {
+            let method = request.method().to_string();
+            let result = request.send_and_reduce().await;
+            process_result(method, result)
+        }
+        Err(e) => process_error(e),
+    }
+}
+
+fn process_result<T>(
+    method: impl Into<MetricRpcMethod>,
+    result: ReducedResult<T>,
+) -> MultiRpcResult<T> {
     match result {
         Ok(value) => MultiRpcResult::Consistent(Ok(value)),
         Err(err) => match err {
             ReductionError::ConsistentError(err) => MultiRpcResult::Consistent(Err(err)),
             ReductionError::InconsistentResults(multi_call_results) => {
                 let results: Vec<_> = multi_call_results.into_iter().collect();
+                let method = method.into();
                 results.iter().for_each(|(source, _service_result)| {
                     if let RpcSource::Supported(provider_id) = source {
                         if let Some(provider) = get_provider(provider_id) {
                             if let Some(host) = hostname(provider.clone()) {
                                 add_metric_entry!(
                                     inconsistent_responses,
-                                    (method.into(), host.into()),
+                                    (method.clone(), host.into()),
                                     1
                                 )
                             }
@@ -33,7 +59,7 @@ pub fn process_result<T>(method: RpcMethod, result: ReducedResult<T>) -> MultiRp
     }
 }
 
-pub fn process_error<T, E: Into<RpcError>>(error: E) -> MultiRpcResult<T> {
+fn process_error<T, E: Into<RpcError>>(error: E) -> MultiRpcResult<T> {
     MultiRpcResult::Consistent(Err(error.into()))
 }
 

--- a/canister/src/main.rs
+++ b/canister/src/main.rs
@@ -2,7 +2,7 @@ use candid::candid_method;
 use canlog::{log, Log, Sort};
 use ic_cdk::{api::is_controller, query, update};
 use ic_metrics_encoder::MetricsEncoder;
-use sol_rpc_canister::candid_rpc::process_request;
+use sol_rpc_canister::candid_rpc::send_multi;
 use sol_rpc_canister::{
     http_types, lifecycle,
     logs::Priority,
@@ -82,7 +82,7 @@ async fn get_account_info(
     params: GetAccountInfoParams,
 ) -> MultiRpcResult<Option<AccountInfo>> {
     let request = MultiRpcRequest::get_account_info(source, config.unwrap_or_default(), params);
-    process_request(request).await.into()
+    send_multi(request).await.into()
 }
 
 #[query(name = "getAccountInfoCyclesCost")]
@@ -112,7 +112,7 @@ async fn get_slot(
         config.unwrap_or_default(),
         params.unwrap_or_default(),
     );
-    process_request(request).await
+    send_multi(request).await
 }
 
 #[query(name = "getSlotCyclesCost")]
@@ -143,7 +143,7 @@ async fn json_request(
 ) -> MultiRpcResult<String> {
     let request =
         MultiRpcRequest::json_request(source, config.unwrap_or_default(), json_rpc_payload);
-    process_request(request)
+    send_multi(request)
         .await
         .map(|value| value.to_string())
 }

--- a/canister/src/main.rs
+++ b/canister/src/main.rs
@@ -143,9 +143,7 @@ async fn json_request(
 ) -> MultiRpcResult<String> {
     let request =
         MultiRpcRequest::json_request(source, config.unwrap_or_default(), json_rpc_payload);
-    send_multi(request)
-        .await
-        .map(|value| value.to_string())
+    send_multi(request).await.map(|value| value.to_string())
 }
 
 #[query(name = "jsonRequestCyclesCost")]

--- a/canister/src/main.rs
+++ b/canister/src/main.rs
@@ -2,14 +2,13 @@ use candid::candid_method;
 use canlog::{log, Log, Sort};
 use ic_cdk::{api::is_controller, query, update};
 use ic_metrics_encoder::MetricsEncoder;
+use sol_rpc_canister::candid_rpc::process_request;
 use sol_rpc_canister::{
-    candid_rpc::{process_error, process_result},
     http_types, lifecycle,
     logs::Priority,
     memory::State,
     memory::{mutate_state, read_state},
     metrics::encode_metrics,
-    metrics::RpcMethod,
     providers::{get_provider, PROVIDERS},
     rpc_client::MultiRpcRequest,
 };
@@ -82,12 +81,8 @@ async fn get_account_info(
     config: Option<RpcConfig>,
     params: GetAccountInfoParams,
 ) -> MultiRpcResult<Option<AccountInfo>> {
-    match MultiRpcRequest::get_account_info(source, config.unwrap_or_default(), params) {
-        Ok(request) => {
-            process_result(RpcMethod::GetAccountInfo, request.send_and_reduce().await).into()
-        }
-        Err(e) => process_error(e),
-    }
+    let request = MultiRpcRequest::get_account_info(source, config.unwrap_or_default(), params);
+    process_request(request).await.into()
 }
 
 #[query(name = "getAccountInfoCyclesCost")]
@@ -112,14 +107,12 @@ async fn get_slot(
     config: Option<GetSlotRpcConfig>,
     params: Option<GetSlotParams>,
 ) -> MultiRpcResult<Slot> {
-    match MultiRpcRequest::get_slot(
+    let request = MultiRpcRequest::get_slot(
         source,
         config.unwrap_or_default(),
         params.unwrap_or_default(),
-    ) {
-        Ok(request) => process_result(RpcMethod::GetSlot, request.send_and_reduce().await),
-        Err(e) => process_error(e),
-    }
+    );
+    process_request(request).await
 }
 
 #[query(name = "getSlotCyclesCost")]
@@ -148,11 +141,11 @@ async fn json_request(
     config: Option<RpcConfig>,
     json_rpc_payload: String,
 ) -> MultiRpcResult<String> {
-    match MultiRpcRequest::json_request(source, config.unwrap_or_default(), json_rpc_payload) {
-        Ok(request) => process_result(RpcMethod::JsonRequest, request.send_and_reduce().await)
-            .map(|value| value.to_string()),
-        Err(e) => process_error(e),
-    }
+    let request =
+        MultiRpcRequest::json_request(source, config.unwrap_or_default(), json_rpc_payload);
+    process_request(request)
+        .await
+        .map(|value| value.to_string())
 }
 
 #[query(name = "jsonRequestCyclesCost")]

--- a/canister/src/metrics/mod.rs
+++ b/canister/src/metrics/mod.rs
@@ -72,12 +72,6 @@ impl<A: MetricLabels, B: MetricLabels, C: MetricLabels> MetricLabels for (A, B, 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, CandidType, Deserialize, From)]
 pub struct MetricRpcMethod(pub String);
 
-impl From<RpcMethod> for MetricRpcMethod {
-    fn from(method: RpcMethod) -> Self {
-        MetricRpcMethod(method.name().to_string())
-    }
-}
-
 impl MetricLabels for MetricRpcMethod {
     fn metric_labels(&self) -> Vec<(&str, &str)> {
         vec![("method", &self.0)]
@@ -137,23 +131,6 @@ pub struct Metrics {
     pub inconsistent_responses: HashMap<(MetricRpcMethod, MetricRpcHost), u64>,
     #[serde(rename = "errHttpOutcall")]
     pub err_http_outcall: HashMap<(MetricRpcMethod, MetricRpcHost, RejectionCode), u64>,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum RpcMethod {
-    GetAccountInfo,
-    GetSlot,
-    JsonRequest,
-}
-
-impl RpcMethod {
-    fn name(self) -> &'static str {
-        match self {
-            RpcMethod::GetAccountInfo => "getAccountInfo",
-            RpcMethod::GetSlot => "getSlot",
-            RpcMethod::JsonRequest => "jsonRequest",
-        }
-    }
 }
 
 trait EncoderExtensions {

--- a/canister/src/rpc_client/mod.rs
+++ b/canister/src/rpc_client/mod.rs
@@ -64,6 +64,9 @@ impl<Params, Output> MultiRpcRequest<Params, Output> {
             _marker: PhantomData,
         }
     }
+    pub fn method(&self) -> &str {
+        self.request.method()
+    }
 }
 
 impl<Params: Clone, Output> Clone for MultiRpcRequest<Params, Output> {


### PR DESCRIPTION
Follow-up on #52 to use the `method` specified by the JSON-RPC request for metrics purposes instead of having a separate enum.