### PR TITLE
feat: default commitment level for `SolRpcClient`

### DIFF
--- a/examples/basic_solana/basic_solana.did
+++ b/examples/basic_solana/basic_solana.did
@@ -2,6 +2,9 @@ type InitArg = record {
     // The canister will interact with this Solana network.
     // If not specified, the value is set to `Devnet`.
     solana_network : opt SolanaNetwork;
+    // Commitment level to use when interacting with the Solana blockchain.
+    // If not specified, the value is set to `finalized`.
+    solana_commitment_level : opt CommitmentLevel;
     // EdDSA keys will be derived from this key.
     // If not specified, the value is set to `TestKeyLocalDevelopment`.
     ed25519_key_name : opt Ed25519KeyName;
@@ -17,6 +20,14 @@ type SolanaNetwork = variant {
     Devnet;
     // Validator and stress testing.
     Testnet;
+};
+
+// Commitment levels in Solana, representing finality guarantees of transactions and state queries.
+// See https://solana.com/de/docs/rpc#configuring-state-commitment.
+type CommitmentLevel = variant {
+  processed;
+  confirmed;
+  finalized;
 };
 
 type Ed25519KeyName = variant {

--- a/examples/basic_solana/src/lib.rs
+++ b/examples/basic_solana/src/lib.rs
@@ -6,7 +6,7 @@ pub mod state;
 use crate::state::read_state;
 use candid::{CandidType, Deserialize, Principal};
 use sol_rpc_client::{IcRuntime, SolRpcClient};
-use sol_rpc_types::{MultiRpcResult, RpcSources, SolanaCluster};
+use sol_rpc_types::{CommitmentLevel, MultiRpcResult, RpcSources, SolanaCluster};
 use solana_hash::Hash;
 use std::{fmt::Display, str::FromStr};
 
@@ -60,6 +60,7 @@ pub fn client() -> SolRpcClient<IcRuntime> {
         .with_rpc_sources(RpcSources::Default(
             read_state(|state| state.solana_network()).into(),
         ))
+        .with_default_commitment_level(CommitmentLevel::Confirmed)
         .build()
 }
 

--- a/examples/basic_solana/src/lib.rs
+++ b/examples/basic_solana/src/lib.rs
@@ -3,7 +3,7 @@ pub mod solana_wallet;
 pub mod spl;
 pub mod state;
 
-use crate::state::read_state;
+use crate::state::{read_state, State};
 use candid::{CandidType, Deserialize, Principal};
 use sol_rpc_client::{IcRuntime, SolRpcClient};
 use sol_rpc_types::{CommitmentLevel, MultiRpcResult, RpcSources, SolanaCluster};
@@ -60,7 +60,7 @@ pub fn client() -> SolRpcClient<IcRuntime> {
         .with_rpc_sources(RpcSources::Default(
             read_state(|state| state.solana_network()).into(),
         ))
-        .with_default_commitment_level(CommitmentLevel::Confirmed)
+        .with_default_commitment_level(read_state(State::solana_commitment_level))
         .build()
 }
 
@@ -69,6 +69,7 @@ pub struct InitArg {
     pub sol_rpc_canister_id: Option<Principal>,
     pub solana_network: Option<SolanaNetwork>,
     pub ed25519_key_name: Option<Ed25519KeyName>,
+    pub solana_commitment_level: Option<CommitmentLevel>,
 }
 
 #[derive(CandidType, Deserialize, Debug, Default, PartialEq, Eq, Clone, Copy)]

--- a/examples/basic_solana/src/main.rs
+++ b/examples/basic_solana/src/main.rs
@@ -7,7 +7,7 @@ use candid::{Nat, Principal};
 use ic_cdk::{init, post_upgrade, update};
 use num::ToPrimitive;
 use serde_json::json;
-use sol_rpc_types::{CommitmentLevel, GetAccountInfoEncoding, GetAccountInfoParams};
+use sol_rpc_types::{GetAccountInfoEncoding, GetAccountInfoParams};
 use solana_account_decoder_client_types::{UiAccountData, UiAccountEncoding};
 use solana_hash::Hash;
 use solana_message::Message;
@@ -75,8 +75,6 @@ pub async fn get_nonce(account: Option<String>) -> String {
     params.encoding = Some(GetAccountInfoEncoding::Base64);
     let account_data = client()
         .get_account_info(params)
-        // TODO XC-350: use commitment level from client
-        .modify_params(|params| params.commitment = Some(CommitmentLevel::Confirmed))
         .send()
         .await
         .expect_consistent()
@@ -140,8 +138,6 @@ pub async fn create_nonce_account(owner: Option<Principal>) -> String {
 
     if let Some(_account) = client
         .get_account_info(*nonce_account.as_ref())
-        // TODO XC-350: use commitment level from client
-        .modify_params(|params| params.commitment = Some(CommitmentLevel::Confirmed))
         .send()
         .await
         .expect_consistent()
@@ -183,8 +179,6 @@ pub async fn create_nonce_account(owner: Option<Principal>) -> String {
 
     client
         .send_transaction(transaction)
-        // TODO XC-350: use commitment level from client
-        .modify_params(|params| params.preflight_commitment = Some(CommitmentLevel::Confirmed))
         .send()
         .await
         .expect_consistent()
@@ -260,8 +254,6 @@ pub async fn send_sol(owner: Option<Principal>, to: String, amount: Nat) -> Stri
 
     client
         .send_transaction(transaction)
-        // TODO XC-350: use commitment level from client
-        .modify_params(|params| params.preflight_commitment = Some(CommitmentLevel::Confirmed))
         .send()
         .await
         .expect_consistent()
@@ -302,8 +294,6 @@ pub async fn send_sol_with_durable_nonce(
 
     client
         .send_transaction(transaction)
-        // TODO XC-350: use commitment level from client
-        .modify_params(|params| params.preflight_commitment = Some(CommitmentLevel::Confirmed))
         .send()
         .await
         .expect_consistent()

--- a/examples/basic_solana/src/state.rs
+++ b/examples/basic_solana/src/state.rs
@@ -3,6 +3,7 @@ use crate::{
     Ed25519KeyName, InitArg, SolanaNetwork,
 };
 use candid::Principal;
+use sol_rpc_types::CommitmentLevel;
 use std::{
     cell::RefCell,
     ops::{Deref, DerefMut},
@@ -31,6 +32,7 @@ where
 pub struct State {
     sol_rpc_canister_id: Option<Principal>,
     solana_network: SolanaNetwork,
+    solana_commitment_level: CommitmentLevel,
     ed25519_public_key: Option<Ed25519ExtendedPublicKey>,
     ed25519_key_name: Ed25519KeyName,
 }
@@ -44,6 +46,10 @@ impl State {
         self.solana_network
     }
 
+    pub fn solana_commitment_level(&self) -> CommitmentLevel {
+        self.solana_commitment_level.clone()
+    }
+
     pub fn sol_rpc_canister_id(&self) -> Option<Principal> {
         self.sol_rpc_canister_id
     }
@@ -54,8 +60,9 @@ impl From<InitArg> for State {
         State {
             sol_rpc_canister_id: init_arg.sol_rpc_canister_id,
             solana_network: init_arg.solana_network.unwrap_or_default(),
+            solana_commitment_level: init_arg.solana_commitment_level.unwrap_or_default(),
+            ed25519_public_key: None,
             ed25519_key_name: init_arg.ed25519_key_name.unwrap_or_default(),
-            ..Default::default()
         }
     }
 }

--- a/examples/basic_solana/tests/tests.rs
+++ b/examples/basic_solana/tests/tests.rs
@@ -5,7 +5,8 @@ use pocket_ic::management_canister::{CanisterId, CanisterSettings};
 use pocket_ic::{PocketIc, PocketIcBuilder};
 use serde::de::DeserializeOwned;
 use sol_rpc_types::{
-    OverrideProvider, RegexSubstitution, RpcAccess, SupportedRpcProvider, SupportedRpcProviderId,
+    CommitmentLevel, OverrideProvider, RegexSubstitution, RpcAccess, SupportedRpcProvider,
+    SupportedRpcProviderId,
 };
 use solana_client::rpc_client::RpcClient as SolanaRpcClient;
 use solana_commitment_config::CommitmentConfig;
@@ -169,6 +170,7 @@ impl Setup {
             sol_rpc_canister_id: Some(sol_rpc_canister_id),
             solana_network: Some(SolanaNetwork::Devnet),
             ed25519_key_name: Some(Ed25519KeyName::ProductionKey1),
+            solana_commitment_level: Some(CommitmentLevel::Confirmed),
         };
         env.install_canister(
             basic_solana_canister_id,

--- a/libs/client/src/lib.rs
+++ b/libs/client/src/lib.rs
@@ -267,6 +267,15 @@ impl<R> ClientBuilder<R> {
         self
     }
 
+    /// Mutates the builder to use the given [`CommitmentLevel`].
+    ///
+    /// All requests made by the built client will use that commitment level.
+    /// This can be overridden by each  request.
+    pub fn with_default_commitment_level(mut self, commitment_level: CommitmentLevel) -> Self {
+        self.config.default_commitment_level = Some(commitment_level);
+        self
+    }
+
     /// Creates a [`SolRpcClient`] from the configuration specified in the [`ClientBuilder`].
     pub fn build(self) -> SolRpcClient<R> {
         SolRpcClient {
@@ -317,7 +326,7 @@ impl<R> SolRpcClient<R> {
     > {
         RequestBuilder::new(
             self.clone(),
-            GetAccountInfoRequest::new(params.into()),
+            GetAccountInfoRequest::new(self.config.default_commitment_level.clone(), params.into()),
             10_000_000_000,
         )
     }

--- a/libs/client/src/lib.rs
+++ b/libs/client/src/lib.rs
@@ -370,7 +370,7 @@ impl<R> SolRpcClient<R> {
     > {
         RequestBuilder::new(
             self.clone(),
-            GetBalanceRequest::new(params.into()),
+            GetBalanceRequest::new(self.config.default_commitment_level.clone(), params.into()),
             10_000_000_000,
         )
     }

--- a/libs/client/src/lib.rs
+++ b/libs/client/src/lib.rs
@@ -134,9 +134,9 @@ use candid::{utils::ArgumentEncoder, CandidType, Principal};
 use ic_cdk::api::call::RejectionCode;
 use serde::de::DeserializeOwned;
 use sol_rpc_types::{
-    GetAccountInfoParams, GetBalanceParams, GetBlockParams, GetSlotParams, GetSlotRpcConfig,
-    GetTransactionParams, Lamport, RpcConfig, RpcSources, SendTransactionParams, Signature,
-    SolanaCluster, SupportedRpcProvider, SupportedRpcProviderId, TransactionDetails,
+    CommitmentLevel, GetAccountInfoParams, GetBalanceParams, GetBlockParams, GetSlotParams,
+    GetSlotRpcConfig, GetTransactionParams, Lamport, RpcConfig, RpcSources, SendTransactionParams,
+    Signature, SolanaCluster, SupportedRpcProvider, SupportedRpcProviderId, TransactionDetails,
     TransactionInfo,
 };
 use solana_clock::Slot;
@@ -214,14 +214,11 @@ impl SolRpcClient<IcRuntime> {
 /// Client to interact with the SOL RPC canister.
 #[derive(Clone, Eq, PartialEq, Debug)]
 pub struct ClientConfig<R> {
-    /// This setup's canister [`Runtime`].
-    pub runtime: R,
-    /// The [`Principal`] of the SOL RPC canister.
-    pub sol_rpc_canister: Principal,
-    /// Configuration for how to perform RPC HTTP calls.
-    pub rpc_config: Option<RpcConfig>,
-    /// Defines what RPC sources to fetch from.
-    pub rpc_sources: RpcSources,
+    runtime: R,
+    sol_rpc_canister: Principal,
+    rpc_config: Option<RpcConfig>,
+    default_commitment_level: Option<CommitmentLevel>,
+    rpc_sources: RpcSources,
 }
 
 /// A [`ClientBuilder`] to create a [`SolRpcClient`] with custom configuration.
@@ -237,6 +234,7 @@ impl<R> ClientBuilder<R> {
                 runtime,
                 sol_rpc_canister,
                 rpc_config: None,
+                default_commitment_level: None,
                 rpc_sources: RpcSources::Default(SolanaCluster::Mainnet),
             },
         }
@@ -251,6 +249,7 @@ impl<R> ClientBuilder<R> {
                 runtime: other_runtime(self.config.runtime),
                 sol_rpc_canister: self.config.sol_rpc_canister,
                 rpc_config: self.config.rpc_config,
+                default_commitment_level: self.config.default_commitment_level,
                 rpc_sources: self.config.rpc_sources,
             },
         }

--- a/libs/client/src/lib.rs
+++ b/libs/client/src/lib.rs
@@ -326,7 +326,7 @@ impl<R> SolRpcClient<R> {
     > {
         RequestBuilder::new(
             self.clone(),
-            GetAccountInfoRequest::new(self.config.default_commitment_level.clone(), params.into()),
+            GetAccountInfoRequest::new(params.into()),
             10_000_000_000,
         )
     }
@@ -370,7 +370,7 @@ impl<R> SolRpcClient<R> {
     > {
         RequestBuilder::new(
             self.clone(),
-            GetBalanceRequest::new(self.config.default_commitment_level.clone(), params.into()),
+            GetBalanceRequest::new(params.into()),
             10_000_000_000,
         )
     }

--- a/libs/client/src/request/mod.rs
+++ b/libs/client/src/request/mod.rs
@@ -111,7 +111,11 @@ impl SolRpcRequest for GetAccountInfoRequest {
 pub struct GetBalanceRequest(GetBalanceParams);
 
 impl GetBalanceRequest {
-    pub fn new(params: GetBalanceParams) -> Self {
+    pub fn new(
+        default_commitment_level: Option<CommitmentLevel>,
+        mut params: GetBalanceParams,
+    ) -> Self {
+        set_default(default_commitment_level, &mut params.commitment);
         Self(params)
     }
 }

--- a/libs/client/src/request/mod.rs
+++ b/libs/client/src/request/mod.rs
@@ -156,20 +156,18 @@ impl SolRpcRequest for GetBlockRequest {
     fn params(self, default_commitment_level: Option<CommitmentLevel>) -> Self::Params {
         let mut params = self.0;
         let default_block_commitment_level =
-            default_commitment_level
-                .clone()
-                .map(|commitment| match commitment {
-                    CommitmentLevel::Processed => {
-                        // The minimum commitment level for `getBlock` is `confirmed,
-                        // `processed` is not supported.
-                        // Not setting a value here would be equivalent to requiring the block to be `finalized`,
-                        // which seems to go against the chosen `default_commitment_level` of `processed` and so `confirmed`
-                        // is the best we can do here.
-                        GetBlockCommitmentLevel::Confirmed
-                    }
-                    CommitmentLevel::Confirmed => GetBlockCommitmentLevel::Confirmed,
-                    CommitmentLevel::Finalized => GetBlockCommitmentLevel::Finalized,
-                });
+            default_commitment_level.map(|commitment| match commitment {
+                CommitmentLevel::Processed => {
+                    // The minimum commitment level for `getBlock` is `confirmed,
+                    // `processed` is not supported.
+                    // Not setting a value here would be equivalent to requiring the block to be `finalized`,
+                    // which seems to go against the chosen `default_commitment_level` of `processed` and so `confirmed`
+                    // is the best we can do here.
+                    GetBlockCommitmentLevel::Confirmed
+                }
+                CommitmentLevel::Confirmed => GetBlockCommitmentLevel::Confirmed,
+                CommitmentLevel::Finalized => GetBlockCommitmentLevel::Finalized,
+            });
         set_default(default_block_commitment_level, &mut params.commitment);
         params
     }

--- a/libs/client/src/request/mod.rs
+++ b/libs/client/src/request/mod.rs
@@ -11,6 +11,7 @@ use sol_rpc_types::{
 };
 use solana_clock::Slot;
 use solana_transaction_status_client_types::EncodedConfirmedTransactionWithStatusMeta;
+use std::fmt::{Debug, Formatter};
 use strum::EnumIter;
 
 /// Solana RPC endpoint supported by the SOL RPC canister.
@@ -418,6 +419,56 @@ pub struct Request<Config, Params, CandidOutput, Output> {
     pub(super) cycles: u128,
     pub(super) _candid_marker: std::marker::PhantomData<CandidOutput>,
     pub(super) _output_marker: std::marker::PhantomData<Output>,
+}
+
+impl<Config: Debug, Params: Debug, CandidOutput, Output> Debug
+    for Request<Config, Params, CandidOutput, Output>
+{
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let Request {
+            endpoint,
+            rpc_sources,
+            rpc_config,
+            params,
+            cycles,
+            _candid_marker,
+            _output_marker,
+        } = &self;
+        f.debug_struct("Request")
+            .field("endpoint", endpoint)
+            .field("rpc_sources", rpc_sources)
+            .field("rpc_config", rpc_config)
+            .field("params", params)
+            .field("cycles", cycles)
+            .field("_candid_marker", _candid_marker)
+            .field("_output_marker", _output_marker)
+            .finish()
+    }
+}
+
+impl<Config: PartialEq, Params: PartialEq, CandidOutput, Output> PartialEq
+    for Request<Config, Params, CandidOutput, Output>
+{
+    fn eq(
+        &self,
+        Request {
+            endpoint,
+            rpc_sources,
+            rpc_config,
+            params,
+            cycles,
+            _candid_marker,
+            _output_marker,
+        }: &Self,
+    ) -> bool {
+        &self.endpoint == endpoint
+            && &self.rpc_sources == rpc_sources
+            && &self.rpc_config == rpc_config
+            && &self.params == params
+            && &self.cycles == cycles
+            && &self._candid_marker == _candid_marker
+            && &self._output_marker == _output_marker
+    }
 }
 
 impl<Config: Clone, Params: Clone, CandidOutput, Output> Clone

--- a/libs/client/src/request/tests.rs
+++ b/libs/client/src/request/tests.rs
@@ -1,45 +1,76 @@
-use crate::SolRpcClient;
-use sol_rpc_types::{CommitmentLevel, GetAccountInfoParams, GetBalanceParams};
+use crate::{SolRpcClient, SolRpcEndpoint};
+use serde_json::json;
+use sol_rpc_types::{
+    CommitmentLevel, GetBlockCommitmentLevel, SendTransactionEncoding, SendTransactionParams,
+};
 use solana_pubkey::pubkey;
+use solana_signature::Signature;
+use strum::IntoEnumIterator;
 
 #[test]
-fn should_override_commitment_level() {
+fn should_set_correct_commitment_level() {
     let pubkey = pubkey!("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v");
     let client_with_commitment_level = SolRpcClient::builder_for_ic()
         .with_default_commitment_level(CommitmentLevel::Confirmed)
         .build();
+    let client_without_commitment_level = SolRpcClient::builder_for_ic().build();
 
-    let builder = client_with_commitment_level.get_account_info(pubkey);
-    assert_eq!(
-        builder.request.params.commitment,
-        Some(CommitmentLevel::Confirmed)
-    );
-
-    let builder = client_with_commitment_level.get_account_info(GetAccountInfoParams {
-        pubkey: pubkey.to_string(),
-        commitment: Some(CommitmentLevel::Processed),
-        encoding: None,
-        data_slice: None,
-        min_context_slot: None,
-    });
-    assert_eq!(
-        builder.request.params.commitment,
-        Some(CommitmentLevel::Processed)
-    );
-
-    let builder = client_with_commitment_level.get_balance(pubkey);
-    assert_eq!(
-        builder.request.params.commitment,
-        Some(CommitmentLevel::Confirmed)
-    );
-
-    let builder = client_with_commitment_level.get_balance(GetBalanceParams {
-        pubkey: pubkey.to_string(),
-        commitment: Some(CommitmentLevel::Processed),
-        min_context_slot: None,
-    });
-    assert_eq!(
-        builder.request.params.commitment,
-        Some(CommitmentLevel::Processed)
-    );
+    for endpoint in SolRpcEndpoint::iter() {
+        match endpoint {
+            SolRpcEndpoint::GetAccountInfo => {
+                let builder = client_with_commitment_level.get_account_info(pubkey);
+                assert_eq!(
+                    builder.request.params.commitment,
+                    Some(CommitmentLevel::Confirmed)
+                );
+            }
+            SolRpcEndpoint::GetBalance => {
+                let builder = client_with_commitment_level.get_balance(pubkey);
+                assert_eq!(
+                    builder.request.params.commitment,
+                    Some(CommitmentLevel::Confirmed)
+                );
+            }
+            SolRpcEndpoint::GetBlock => {
+                let builder = client_with_commitment_level.get_block(1_u64);
+                assert_eq!(
+                    builder.request.params.commitment,
+                    Some(GetBlockCommitmentLevel::Confirmed)
+                );
+            }
+            SolRpcEndpoint::GetSlot => {
+                let builder = client_with_commitment_level.get_slot();
+                assert_eq!(
+                    builder.request.params.and_then(|p| p.commitment),
+                    Some(CommitmentLevel::Confirmed)
+                );
+            }
+            SolRpcEndpoint::GetTransaction => {
+                let builder = client_with_commitment_level.get_transaction("tspfR5p1PFphquz4WzDb7qM4UhJdgQXkEZtW88BykVEdX2zL2kBT9kidwQBviKwQuA3b6GMCR1gknHvzQ3r623T".parse::<Signature>().unwrap());
+                assert_eq!(
+                    builder.request.params.commitment,
+                    Some(CommitmentLevel::Confirmed)
+                );
+            }
+            SolRpcEndpoint::JsonRequest => {
+                let json_req = json!({ "jsonrpc": "2.0", "id": 1, "method": "getVersion" });
+                let builder_with_level =
+                    client_with_commitment_level.json_request(json_req.clone());
+                let builder_without_level = client_without_commitment_level.json_request(json_req);
+                assert_eq!(builder_with_level.request, builder_without_level.request);
+            }
+            SolRpcEndpoint::SendTransaction => {
+                let builder = client_with_commitment_level.send_transaction(
+                    SendTransactionParams::from_encoded_transaction(
+                        "abcD".to_string(),
+                        SendTransactionEncoding::Base64,
+                    ),
+                );
+                assert_eq!(
+                    builder.request.params.preflight_commitment,
+                    Some(CommitmentLevel::Confirmed)
+                );
+            }
+        }
+    }
 }

--- a/libs/client/src/request/tests.rs
+++ b/libs/client/src/request/tests.rs
@@ -1,0 +1,45 @@
+use crate::SolRpcClient;
+use sol_rpc_types::{CommitmentLevel, GetAccountInfoParams, GetBalanceParams};
+use solana_pubkey::pubkey;
+
+#[test]
+fn should_override_commitment_level() {
+    let pubkey = pubkey!("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v");
+    let client_with_commitment_level = SolRpcClient::builder_for_ic()
+        .with_default_commitment_level(CommitmentLevel::Confirmed)
+        .build();
+
+    let builder = client_with_commitment_level.get_account_info(pubkey);
+    assert_eq!(
+        builder.request.params.commitment,
+        Some(CommitmentLevel::Confirmed)
+    );
+
+    let builder = client_with_commitment_level.get_account_info(GetAccountInfoParams {
+        pubkey: pubkey.to_string(),
+        commitment: Some(CommitmentLevel::Processed),
+        encoding: None,
+        data_slice: None,
+        min_context_slot: None,
+    });
+    assert_eq!(
+        builder.request.params.commitment,
+        Some(CommitmentLevel::Processed)
+    );
+
+    let builder = client_with_commitment_level.get_balance(pubkey);
+    assert_eq!(
+        builder.request.params.commitment,
+        Some(CommitmentLevel::Confirmed)
+    );
+
+    let builder = client_with_commitment_level.get_balance(GetBalanceParams {
+        pubkey: pubkey.to_string(),
+        commitment: Some(CommitmentLevel::Processed),
+        min_context_slot: None,
+    });
+    assert_eq!(
+        builder.request.params.commitment,
+        Some(CommitmentLevel::Processed)
+    );
+}

--- a/libs/types/src/solana/request/mod.rs
+++ b/libs/types/src/solana/request/mod.rs
@@ -346,7 +346,7 @@ pub enum SendTransactionEncoding {
 
 /// [Commitment levels](https://solana.com/docs/rpc#configuring-state-commitment) in Solana,
 /// representing finality guarantees of transactions and memory queries.
-#[derive(Debug, Clone, Deserialize, Serialize, CandidType)]
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize, CandidType)]
 pub enum CommitmentLevel {
     /// The transaction is processed by a leader, but may be dropped.
     #[serde(rename = "processed")]

--- a/libs/types/src/solana/request/mod.rs
+++ b/libs/types/src/solana/request/mod.rs
@@ -371,7 +371,7 @@ impl From<CommitmentLevel> for solana_commitment_config::CommitmentConfig {
 
 /// Subset of [`CommitmentLevel`] whose variants are allowed values for the `encoding`
 /// field of [`GetBlockParams`].
-#[derive(Debug, Clone, Deserialize, Serialize, CandidType)]
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize, CandidType)]
 pub enum GetBlockCommitmentLevel {
     /// See [`CommitmentLevel::Confirmed`].
     #[serde(rename = "confirmed")]

--- a/libs/types/src/solana/request/mod.rs
+++ b/libs/types/src/solana/request/mod.rs
@@ -346,7 +346,7 @@ pub enum SendTransactionEncoding {
 
 /// [Commitment levels](https://solana.com/docs/rpc#configuring-state-commitment) in Solana,
 /// representing finality guarantees of transactions and memory queries.
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize, CandidType)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize, CandidType)]
 pub enum CommitmentLevel {
     /// The transaction is processed by a leader, but may be dropped.
     #[serde(rename = "processed")]
@@ -356,6 +356,7 @@ pub enum CommitmentLevel {
     Confirmed,
     /// The transaction is finalized and cannot be rolled back.
     #[serde(rename = "finalized")]
+    #[default]
     Finalized,
 }
 


### PR DESCRIPTION
Follow-up on #75 that improves the `SolRpcClient` by being able to set in the client builder a default commitment level that will be used by the built client for all future requests. This is similar to what the Solana client offers with [`new_with_commitment`](https://docs.rs/solana-client/latest/solana_client/rpc_client/struct.RpcClient.html#method.new_with_commitment).