### PR TITLE
test: integration test for `verifyApiKey`

### DIFF
--- a/canister/src/main.rs
+++ b/canister/src/main.rs
@@ -347,8 +347,7 @@ fn http_request(request: HttpRequest) -> HttpResponse {
     name = "verifyApiKey",
     hidden = true
 )]
-async fn verify_api_key(api_key: (SupportedRpcProviderId, Option<String>)) {
-    let (provider, api_key) = api_key;
+async fn verify_api_key((provider, api_key): (SupportedRpcProviderId, Option<String>)) {
     let api_key = api_key.map(|key| TryFrom::try_from(key).expect("Invalid API key"));
     if read_state(|state| state.get_api_key(&provider)) != api_key {
         panic!("API key does not match input")

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -146,7 +146,6 @@ impl Setup {
         self
     }
 
-    // TODO XC-329: remove verifyApiKey endpoint
     pub async fn verify_api_key(&self, api_key: (SupportedRpcProviderId, Option<String>)) {
         let runtime = self.new_pocket_ic_runtime();
         runtime
@@ -217,6 +216,10 @@ impl Setup {
     pub fn controller(&self) -> Principal {
         self.controller
     }
+
+    pub fn sol_rpc_canister_id(&self) -> CanisterId {
+        self.sol_rpc_canister_id
+    }
 }
 
 async fn tick_until_http_request(env: &PocketIc) -> Vec<CanisterHttpRequest> {
@@ -248,6 +251,12 @@ fn wallet_wasm() -> Vec<u8> {
         )
     };
     ic_test_utilities_load_wasm::load_wasm(PathBuf::new(), "wallet", &[])
+}
+
+impl AsRef<PocketIc> for Setup {
+    fn as_ref(&self) -> &PocketIc {
+        &self.env
+    }
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
The endpoint `verifyApiKey` is useful for debugging and testing purposes to ensure that an API key for a given provider is correctly set. This is also obviously a sensitive endpoint and proper access control should be in place to avoid security issues such as leaking the API key. An integration test with Pocket IC was added to ensure that is the case.