### PR TITLE
fix: set `maxSupportedTransactionVersion` to zero for end-to-end tests

### DIFF
--- a/canister/scripts/examples.sh
+++ b/canister/scripts/examples.sh
@@ -38,7 +38,7 @@ GET_BLOCK_PARAMS="(
     slot = ${SLOT};
     commitment = opt variant { finalized };
     transactionDetails = opt variant { signatures };
-    maxSupportedTransactionVersion = null;
+    maxSupportedTransactionVersion = opt (0 : nat8);
   },
 )"
 CYCLES=$(dfx canister call sol_rpc getBlockCyclesCost "$GET_BLOCK_PARAMS" $FLAGS --output json | jq '.Ok' --raw-output || exit 1)
@@ -58,7 +58,7 @@ GET_TRANSACTION_PARAMS="(
     signature = \"${SIGNATURE}\";
     commitment = opt variant { finalized };
     encoding = opt variant{ base64 };
-    maxSupportedTransactionVersion = null;
+    maxSupportedTransactionVersion = opt (0 : nat8);
   },
 )"
 CYCLES=$(dfx canister call sol_rpc getTransactionCyclesCost "$GET_TRANSACTION_PARAMS" $FLAGS --output json | jq '.Ok' --raw-output || exit 1)


### PR DESCRIPTION
Solana introduced a new transaction format with [versioned transactions](https://solana.com/de/developers/guides/advanced/versions). The calls for `getBlock` and `getTransaction` must specify a `maxSupportedTransactionVersion` (currently the most recent version is `0`) to avoid failing in case the response contains any version `0` transactions.