### PR TITLE
feat: add support for `getTokenAccountBalance` RPC method

### DIFF
--- a/canister/scripts/examples.sh
+++ b/canister/scripts/examples.sh
@@ -86,6 +86,7 @@ GET_ACCOUNT_INFO_PARAMS="(
 CYCLES=$(dfx canister call sol_rpc getAccountInfoCyclesCost "$GET_ACCOUNT_INFO_PARAMS" $FLAGS --output json | jq '.Ok' --raw-output || exit 1)
 dfx canister call sol_rpc getAccountInfo "$GET_ACCOUNT_INFO_PARAMS" $FLAGS --with-cycles "$CYCLES" || exit 1
 
+# Get the USDC mint account balance on Mainnet with a 2-out-of-3 strategy
 GET_BALANCE_PARAMS="(
   variant { Default = variant { Mainnet } },
   opt record {
@@ -102,3 +103,20 @@ GET_BALANCE_PARAMS="(
 )"
 CYCLES=$(dfx canister call sol_rpc getBalanceCyclesCost "$GET_BALANCE_PARAMS" $FLAGS --output json | jq '.Ok' --raw-output || exit 1)
 dfx canister call sol_rpc getBalance "$GET_BALANCE_PARAMS" $FLAGS --with-cycles "$CYCLES" || exit 1
+
+# Get the USDC issuer (Circle) token account balance on Mainnet with a 2-out-of-3 strategy
+GET_TOKEN_ACCOUNT_BALANCE_PARAMS="(
+  variant { Default = variant { Mainnet } },
+  opt record {
+    responseConsensus = opt variant {
+      Threshold = record { min = 2 : nat8; total = opt (3 : nat8) }
+    };
+    responseSizeEstimate = null;
+  },
+  record {
+    pubkey = \"3emsAVdmGKERbHjmGfQ6oZ1e35dkf5iYcS6U4CPKFVaa\";
+    commitment = null;
+  },
+)"
+CYCLES=$(dfx canister call sol_rpc getTokenAccountBalanceCyclesCost "$GET_TOKEN_ACCOUNT_BALANCE_PARAMS" $FLAGS --output json | jq '.Ok' --raw-output || exit 1)
+dfx canister call sol_rpc getTokenAccountBalance "$GET_TOKEN_ACCOUNT_BALANCE_PARAMS" $FLAGS --with-cycles "$CYCLES" || exit 1

--- a/canister/sol_rpc_canister.did
+++ b/canister/sol_rpc_canister.did
@@ -579,6 +579,23 @@ type MultiGetSlotResult = variant {
     Inconsistent : vec record { RpcSource; GetSlotResult };
 };
 
+// The parameters for a Solana `getTokenAccountBalance` RPC method call.
+type GetTokenAccountBalanceParams = record {
+  // Pubkey of token account to query, as base-58 encoded string.
+  pubkey: Pubkey;
+  // The commitment describes how finalized a block is at that point in time.
+  commitment: opt CommitmentLevel;
+};
+
+// Represents the result of a call to the `getTokenAccountBalance` Solana RPC method.
+type GetTokenAccountBalanceResult = variant { Ok : TokenAmount; Err : RpcError };
+
+// Represents an aggregated result from multiple RPC calls to the `getTokenAccountBalance` Solana RPC method.
+type MultiGetTokenAccountBalanceResult = variant {
+    Consistent : GetTokenAccountBalanceResult;
+    Inconsistent : vec record { RpcSource; GetTokenAccountBalanceResult };
+};
+
 // Represents the result of a call to the `sendTransaction` Solana RPC method.
 type SendTransactionResult = variant { Ok : Signature; Err : RpcError };
 
@@ -663,11 +680,11 @@ service : (InstallArgs,) -> {
   // The caller is the controller or a principal specified in `InstallArgs::manage_api_keys`.
   updateApiKeys : (vec record { SupportedProvider; opt text }) -> ();
 
-  // Call the Solana `getAccountInfo` RPC method and return the resulting slot.
+  // Call the Solana `getAccountInfo` RPC method and return the resulting info.
   getAccountInfo : (RpcSources, opt RpcConfig, GetAccountInfoParams) -> (MultiGetAccountInfoResult);
   getAccountInfoCyclesCost : (RpcSources, opt RpcConfig, GetAccountInfoParams) -> (RequestCostResult) query;
 
-  // Call the Solana `getBalance` RPC method and return the resulting block.
+  // Call the Solana `getBalance` RPC method and return the resulting balance.
   getBalance : (RpcSources, opt RpcConfig, GetBalanceParams) -> (MultiGetBalanceResult);
   getBalanceCyclesCost : (RpcSources, opt RpcConfig, GetBalanceParams) -> (RequestCostResult) query;
 
@@ -679,7 +696,11 @@ service : (InstallArgs,) -> {
   getSlot : (RpcSources, opt GetSlotRpcConfig, opt GetSlotParams) -> (MultiGetSlotResult);
   getSlotCyclesCost : (RpcSources, opt GetSlotRpcConfig, opt GetSlotParams) -> (RequestCostResult) query;
 
-  // Call the Solana `getTransaction` RPC method and return the resulting slot.
+  // Call the Solana `getTokenAccountBalance` RPC method and return the resulting balance.
+  getTokenAccountBalance : (RpcSources, opt RpcConfig, GetTokenAccountBalanceParams) -> (MultiGetTokenAccountBalanceResult);
+  getTokenAccountBalanceCyclesCost : (RpcSources, opt RpcConfig, GetTokenAccountBalanceParams) -> (RequestCostResult) query;
+
+  // Call the Solana `getTransaction` RPC method and return the resulting transaction.
   getTransaction : (RpcSources, opt RpcConfig, GetTransactionParams) -> (MultiGetTransactionResult);
   getTransactionCyclesCost : (RpcSources, opt RpcConfig, GetTransactionParams) -> (RequestCostResult) query;
 

--- a/canister/sol_rpc_canister.did
+++ b/canister/sol_rpc_canister.did
@@ -697,6 +697,7 @@ service : (InstallArgs,) -> {
   getSlotCyclesCost : (RpcSources, opt GetSlotRpcConfig, opt GetSlotParams) -> (RequestCostResult) query;
 
   // Call the Solana `getTokenAccountBalance` RPC method and return the resulting balance.
+  // If the account does not exist, this method will return a JSON-RPC error.
   getTokenAccountBalance : (RpcSources, opt RpcConfig, GetTokenAccountBalanceParams) -> (MultiGetTokenAccountBalanceResult);
   getTokenAccountBalanceCyclesCost : (RpcSources, opt RpcConfig, GetTokenAccountBalanceParams) -> (RequestCostResult) query;
 

--- a/canister/src/main.rs
+++ b/canister/src/main.rs
@@ -14,9 +14,9 @@ use sol_rpc_canister::{
 };
 use sol_rpc_types::{
     AccountInfo, ConfirmedBlock, GetAccountInfoParams, GetBalanceParams, GetBlockParams,
-    GetSlotParams, GetSlotRpcConfig, GetTransactionParams, Lamport, MultiRpcResult, RpcAccess,
-    RpcConfig, RpcResult, RpcSources, SendTransactionParams, Signature, Slot, SupportedRpcProvider,
-    SupportedRpcProviderId, TransactionInfo,
+    GetSlotParams, GetSlotRpcConfig, GetTokenAccountBalanceParams, GetTransactionParams, Lamport,
+    MultiRpcResult, RpcAccess, RpcConfig, RpcResult, RpcSources, SendTransactionParams, Signature,
+    Slot, SupportedRpcProvider, SupportedRpcProviderId, TokenAmount, TransactionInfo,
 };
 use std::str::FromStr;
 
@@ -186,6 +186,33 @@ async fn get_slot_cycles_cost(
     )?
     .cycles_cost()
     .await
+}
+
+#[update(name = "getTokenAccountBalance")]
+#[candid_method(rename = "getTokenAccountBalance")]
+async fn get_token_account_balance(
+    source: RpcSources,
+    config: Option<RpcConfig>,
+    params: GetTokenAccountBalanceParams,
+) -> MultiRpcResult<TokenAmount> {
+    let request =
+        MultiRpcRequest::get_token_account_balance(source, config.unwrap_or_default(), params);
+    send_multi(request).await.into()
+}
+
+#[query(name = "getTokenAccountBalanceCyclesCost")]
+#[candid_method(query, rename = "getTokenAccountBalanceCyclesCost")]
+async fn get_token_account_balance_cycles_cost(
+    source: RpcSources,
+    config: Option<RpcConfig>,
+    params: GetTokenAccountBalanceParams,
+) -> RpcResult<u128> {
+    if read_state(State::is_demo_mode_active) {
+        return Ok(0);
+    }
+    MultiRpcRequest::get_token_account_balance(source, config.unwrap_or_default(), params)?
+        .cycles_cost()
+        .await
 }
 
 #[update(name = "getTransaction")]

--- a/canister/src/rpc_client/json/mod.rs
+++ b/canister/src/rpc_client/json/mod.rs
@@ -165,6 +165,36 @@ pub struct GetBlockConfig {
 
 #[skip_serializing_none]
 #[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(into = "(String, Option<GetTokenAccountBalanceConfig>)")]
+pub struct GetTokenAccountBalanceParams(String, Option<GetTokenAccountBalanceConfig>);
+
+#[skip_serializing_none]
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct GetTokenAccountBalanceConfig {
+    pub commitment: Option<CommitmentLevel>,
+}
+
+impl From<sol_rpc_types::GetTokenAccountBalanceParams> for GetTokenAccountBalanceParams {
+    fn from(params: sol_rpc_types::GetTokenAccountBalanceParams) -> Self {
+        Self(
+            params.pubkey,
+            params
+                .commitment
+                .map(|commitment| GetTokenAccountBalanceConfig {
+                    commitment: Some(commitment),
+                }),
+        )
+    }
+}
+
+impl From<GetTokenAccountBalanceParams> for (String, Option<GetTokenAccountBalanceConfig>) {
+    fn from(value: GetTokenAccountBalanceParams) -> Self {
+        (value.0, value.1)
+    }
+}
+
+#[skip_serializing_none]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(into = "(String, Option<GetTransactionConfig>)")]
 pub struct GetTransactionParams(String, Option<GetTransactionConfig>);
 

--- a/canister/src/rpc_client/mod.rs
+++ b/canister/src/rpc_client/mod.rs
@@ -208,7 +208,7 @@ impl GetTokenAccountBalanceRequest {
         let providers = Providers::new(rpc_sources, consensus_strategy.clone())?;
         let max_response_bytes = config
             .response_size_estimate
-            .unwrap_or(256 + HEADER_SIZE_LIMIT);
+            .unwrap_or(1024 + HEADER_SIZE_LIMIT);
 
         Ok(MultiRpcRequest::new(
             providers,

--- a/canister/src/rpc_client/mod.rs
+++ b/canister/src/rpc_client/mod.rs
@@ -193,6 +193,33 @@ impl GetSlotRequest {
     }
 }
 
+pub type GetTokenAccountBalanceRequest = MultiRpcRequest<
+    json::GetTokenAccountBalanceParams,
+    solana_account_decoder_client_types::token::UiTokenAmount,
+>;
+
+impl GetTokenAccountBalanceRequest {
+    pub fn get_token_account_balance<Params: Into<json::GetTokenAccountBalanceParams>>(
+        rpc_sources: RpcSources,
+        config: RpcConfig,
+        params: Params,
+    ) -> Result<Self, ProviderError> {
+        let consensus_strategy = config.response_consensus.unwrap_or_default();
+        let providers = Providers::new(rpc_sources, consensus_strategy.clone())?;
+        let max_response_bytes = config
+            .response_size_estimate
+            .unwrap_or(256 + HEADER_SIZE_LIMIT);
+
+        Ok(MultiRpcRequest::new(
+            providers,
+            JsonRpcRequest::new("getTokenAccountBalance", params.into()),
+            max_response_bytes,
+            ResponseTransform::GetTokenAccountBalance,
+            ReductionStrategy::from(consensus_strategy),
+        ))
+    }
+}
+
 pub type GetTransactionRequest = MultiRpcRequest<
     json::GetTransactionParams,
     Option<solana_transaction_status_client_types::EncodedConfirmedTransactionWithStatusMeta>,

--- a/canister/src/rpc_client/sol_rpc/mod.rs
+++ b/canister/src/rpc_client/sol_rpc/mod.rs
@@ -26,12 +26,14 @@ pub enum ResponseTransform {
     #[n(2)]
     GetBlock,
     #[n(3)]
-    GetSlot(#[n(0)] RoundingError),
-    #[n(4)]
-    GetTransaction,
+    GetSlot(#[n(4)] RoundingError),
     #[n(5)]
-    SendTransaction,
+    GetTokenAccountBalance,
     #[n(6)]
+    GetTransaction,
+    #[n(7)]
+    SendTransaction,
+    #[n(8)]
     Raw,
 }
 
@@ -75,6 +77,9 @@ impl ResponseTransform {
                     Value::Null => None,
                     value => Some(value),
                 });
+            }
+            Self::GetTokenAccountBalance => {
+                canonicalize_response::<Value, Value>(body_bytes, |result| result["value"].clone());
             }
             Self::SendTransaction => {
                 canonicalize_response::<String, String>(body_bytes, std::convert::identity);

--- a/canister/src/rpc_client/sol_rpc/mod.rs
+++ b/canister/src/rpc_client/sol_rpc/mod.rs
@@ -26,14 +26,14 @@ pub enum ResponseTransform {
     #[n(2)]
     GetBlock,
     #[n(3)]
-    GetSlot(#[n(4)] RoundingError),
-    #[n(5)]
+    GetSlot(#[n(0)] RoundingError),
+    #[n(4)]
     GetTokenAccountBalance,
-    #[n(6)]
+    #[n(5)]
     GetTransaction,
-    #[n(7)]
+    #[n(6)]
     SendTransaction,
-    #[n(8)]
+    #[n(7)]
     Raw,
 }
 

--- a/canister/src/rpc_client/tests.rs
+++ b/canister/src/rpc_client/tests.rs
@@ -16,7 +16,7 @@ mod request_serialization_tests {
 
     #[test]
     fn should_serialize_get_account_info_request() {
-        assert_serialized(
+        assert_params_eq(
             GetAccountInfoRequest::get_account_info(
                 RpcSources::Default(SolanaCluster::Mainnet),
                 RpcConfig::default(),
@@ -25,7 +25,7 @@ mod request_serialization_tests {
             .unwrap(),
             json!(["11111111111111111111111111111111", null]),
         );
-        assert_serialized(
+        assert_params_eq(
             GetAccountInfoRequest::get_account_info(
                 RpcSources::Default(SolanaCluster::Mainnet),
                 RpcConfig::default(),
@@ -54,7 +54,7 @@ mod request_serialization_tests {
 
     #[test]
     fn should_serialize_get_slot_request() {
-        assert_serialized(
+        assert_params_eq(
             GetSlotRequest::get_slot(
                 RpcSources::Default(SolanaCluster::Mainnet),
                 GetSlotRpcConfig::default(),
@@ -63,7 +63,7 @@ mod request_serialization_tests {
             .unwrap(),
             json!([null]),
         );
-        assert_serialized(
+        assert_params_eq(
             GetSlotRequest::get_slot(
                 RpcSources::Default(SolanaCluster::Mainnet),
                 GetSlotRpcConfig::default(),
@@ -85,7 +85,7 @@ mod request_serialization_tests {
     #[test]
     fn should_serialize_get_transaction_request() {
         let signature = solana_signature::Signature::default().to_string();
-        assert_serialized(
+        assert_params_eq(
             GetTransactionRequest::get_transaction(
                 RpcSources::Default(SolanaCluster::Mainnet),
                 RpcConfig::default(),
@@ -94,7 +94,7 @@ mod request_serialization_tests {
             .unwrap(),
             json!([signature, null]),
         );
-        assert_serialized(
+        assert_params_eq(
             GetTransactionRequest::get_transaction(
                 RpcSources::Default(SolanaCluster::Mainnet),
                 RpcConfig::default(),
@@ -120,7 +120,7 @@ mod request_serialization_tests {
     #[test]
     fn should_serialize_get_balance_request() {
         let pubkey = solana_pubkey::Pubkey::default();
-        assert_serialized(
+        assert_params_eq(
             MultiRpcRequest::get_balance(
                 RpcSources::Default(SolanaCluster::Mainnet),
                 RpcConfig::default(),
@@ -130,7 +130,7 @@ mod request_serialization_tests {
             json!([pubkey.to_string(), null]),
         );
 
-        assert_serialized(
+        assert_params_eq(
             MultiRpcRequest::get_balance(
                 RpcSources::Default(SolanaCluster::Mainnet),
                 RpcConfig::default(),
@@ -156,7 +156,7 @@ mod request_serialization_tests {
     #[test]
     fn should_serialize_get_token_account_balance_request() {
         let pubkey = solana_pubkey::Pubkey::default();
-        assert_serialized(
+        assert_params_eq(
             MultiRpcRequest::get_token_account_balance(
                 RpcSources::Default(SolanaCluster::Mainnet),
                 RpcConfig::default(),
@@ -166,7 +166,7 @@ mod request_serialization_tests {
             json!([pubkey.to_string(), null]),
         );
 
-        assert_serialized(
+        assert_params_eq(
             MultiRpcRequest::get_token_account_balance(
                 RpcSources::Default(SolanaCluster::Mainnet),
                 RpcConfig::default(),
@@ -185,7 +185,7 @@ mod request_serialization_tests {
 
     #[test]
     fn should_serialize_get_block_request() {
-        assert_serialized(
+        assert_params_eq(
             GetBlockRequest::get_block(
                 RpcSources::Default(SolanaCluster::Mainnet),
                 RpcConfig::default(),
@@ -197,7 +197,7 @@ mod request_serialization_tests {
                 {"rewards": false, "transactionDetails": "none"}
             ]),
         );
-        assert_serialized(
+        assert_params_eq(
             GetBlockRequest::get_block(
                 RpcSources::Default(SolanaCluster::Mainnet),
                 RpcConfig::default(),
@@ -224,7 +224,7 @@ mod request_serialization_tests {
     #[test]
     fn should_serialize_send_transaction_request() {
         let transaction = "4F9ksKhLSgn9e7ugVnAmRpRXL9kjke4TT96FNDxMiUNc5KVDz8p1yuv";
-        assert_serialized(
+        assert_params_eq(
             SendTransactionRequest::send_transaction(
                 RpcSources::Default(SolanaCluster::Mainnet),
                 RpcConfig::default(),
@@ -244,7 +244,7 @@ mod request_serialization_tests {
         params.skip_preflight = Some(true);
         params.preflight_commitment = Some(CommitmentLevel::Processed);
         params.min_context_slot = Some(456);
-        assert_serialized(
+        assert_params_eq(
             SendTransactionRequest::send_transaction(
                 RpcSources::Default(SolanaCluster::Mainnet),
                 RpcConfig::default(),
@@ -264,7 +264,7 @@ mod request_serialization_tests {
         );
     }
 
-    fn assert_serialized<Params: Serialize, Output>(
+    fn assert_params_eq<Params: Serialize, Output>(
         request: MultiRpcRequest<Params, Output>,
         serialized: serde_json::Value,
     ) {

--- a/canister/src/rpc_client/tests.rs
+++ b/canister/src/rpc_client/tests.rs
@@ -5,15 +5,14 @@ use crate::rpc_client::{
 use serde::Serialize;
 use serde_json::json;
 use sol_rpc_types::{
-    CommitmentLevel, DataSlice, GetAccountInfoEncoding, GetAccountInfoParams,
+    CommitmentLevel, DataSlice, GetAccountInfoEncoding, GetAccountInfoParams, GetBalanceParams,
     GetBlockCommitmentLevel, GetBlockParams, GetSlotParams, GetSlotRpcConfig,
-    GetTransactionEncoding, GetTransactionParams, RpcConfig, RpcSources, SendTransactionEncoding,
-    SendTransactionParams, SolanaCluster, TransactionDetails,
+    GetTokenAccountBalanceParams, GetTransactionEncoding, GetTransactionParams, RpcConfig,
+    RpcSources, SendTransactionEncoding, SendTransactionParams, SolanaCluster, TransactionDetails,
 };
 
 mod request_serialization_tests {
     use super::*;
-    use sol_rpc_types::GetBalanceParams;
 
     #[test]
     fn should_serialize_get_account_info_request() {
@@ -151,6 +150,36 @@ mod request_serialization_tests {
                     }
                 ]
             ),
+        );
+    }
+
+    #[test]
+    fn should_serialize_get_token_account_balance_request() {
+        let pubkey = solana_pubkey::Pubkey::default();
+        assert_serialized(
+            MultiRpcRequest::get_token_account_balance(
+                RpcSources::Default(SolanaCluster::Mainnet),
+                RpcConfig::default(),
+                GetTokenAccountBalanceParams::from(pubkey),
+            )
+            .unwrap(),
+            json!([pubkey.to_string(), null]),
+        );
+
+        assert_serialized(
+            MultiRpcRequest::get_token_account_balance(
+                RpcSources::Default(SolanaCluster::Mainnet),
+                RpcConfig::default(),
+                GetTokenAccountBalanceParams {
+                    pubkey: pubkey.to_string(),
+                    commitment: Some(CommitmentLevel::Confirmed),
+                },
+            )
+            .unwrap(),
+            json!([
+                pubkey.to_string(),
+                {"commitment": "confirmed"}
+            ]),
         );
     }
 

--- a/examples/basic_solana/basic_solana.did
+++ b/examples/basic_solana/basic_solana.did
@@ -51,6 +51,18 @@ type Txid = text;
 // Hash value used as recent_blockhash field in Transactions.
 type Blockhash = text;
 
+// A human-readable representation of a token amount, as returned by the Solana `getTokenAccountBalance` RPC method.
+type TokenAmount = record {
+  // The raw balance without decimals, a string representation of a nat64.
+  amount : text;
+  // Number of base 10 digits to the right of the decimal place.
+  decimals : nat8;
+  // DEPRECATED: The balance, using mint-prescribed decimals.
+  uiAmount : opt float64;
+  // The balance as a string, using mint-prescribed decimals.
+  uiAmountString : text;
+};
+
 service : (InitArg) -> {
     // Returns the Solana account derived from the owner principal.
     //
@@ -82,7 +94,7 @@ service : (InitArg) -> {
     // the given token mint account formatted as a string.
     //
     // If no account is provided, the account derived from the caller's principal is used.
-    get_spl_token_balance : (account: opt Address, mint_account: Address) -> (text);
+    get_spl_token_balance : (account: opt Address, mint_account: Address) -> (TokenAmount);
 
     // Creates a nonce account with the given Solana account as nonce authority. Returns the
     // resulting nonce account address.

--- a/examples/basic_solana/basic_solana.did
+++ b/examples/basic_solana/basic_solana.did
@@ -79,10 +79,10 @@ service : (InitArg) -> {
     get_nonce : (account: opt Address) -> (Blockhash);
 
     // Returns the balance of the given Solana account for the SPL token associated with
-    // the given token mint account.
+    // the given token mint account formatted as a string.
     //
     // If no account is provided, the account derived from the caller's principal is used.
-    get_spl_token_balance : (account: opt Address, mint_account: Address) -> (nat);
+    get_spl_token_balance : (account: opt Address, mint_account: Address) -> (text);
 
     // Creates a nonce account with the given Solana account as nonce authority. Returns the
     // resulting nonce account address.

--- a/examples/basic_solana/src/main.rs
+++ b/examples/basic_solana/src/main.rs
@@ -6,7 +6,7 @@ use basic_solana::{
 use candid::{Nat, Principal};
 use ic_cdk::{init, post_upgrade, update};
 use num::ToPrimitive;
-use sol_rpc_types::{GetAccountInfoEncoding, GetAccountInfoParams};
+use sol_rpc_types::{GetAccountInfoEncoding, GetAccountInfoParams, TokenAmount};
 use solana_account_decoder_client_types::{UiAccountData, UiAccountEncoding};
 use solana_hash::Hash;
 use solana_message::Message;
@@ -99,7 +99,7 @@ pub async fn get_nonce(account: Option<String>) -> String {
 }
 
 #[update]
-pub async fn get_spl_token_balance(account: Option<String>, mint_account: String) -> String {
+pub async fn get_spl_token_balance(account: Option<String>, mint_account: String) -> TokenAmount {
     let account = account.unwrap_or(associated_token_account(None, mint_account).await);
     let public_key = Pubkey::from_str(&account).unwrap();
     client()
@@ -108,7 +108,7 @@ pub async fn get_spl_token_balance(account: Option<String>, mint_account: String
         .await
         .expect_consistent()
         .expect("Call to `getTokenAccountBalance` failed")
-        .ui_amount_string
+        .into()
 }
 
 #[update]

--- a/examples/basic_solana/tests/tests.rs
+++ b/examples/basic_solana/tests/tests.rs
@@ -9,7 +9,7 @@ use pocket_ic::{
 use serde::de::DeserializeOwned;
 use sol_rpc_types::{
     CommitmentLevel, OverrideProvider, RegexSubstitution, RpcAccess, SupportedRpcProvider,
-    SupportedRpcProviderId,
+    SupportedRpcProviderId, TokenAmount,
 };
 use solana_client::{rpc_client::RpcClient as SolanaRpcClient, rpc_config::RpcTransactionConfig};
 use solana_commitment_config::CommitmentConfig;
@@ -204,7 +204,7 @@ fn test_basic_solana() {
         .unwrap()
         .expect("Missing user's associated token account");
     assert_eq!(token_account.token_amount.amount, "999999000");
-    let sender_spl_balance: String = basic_solana.update_call(
+    let sender_spl_balance: TokenAmount = basic_solana.update_call(
         SENDER,
         "get_spl_token_balance",
         (
@@ -212,14 +212,22 @@ fn test_basic_solana() {
             mint_account.to_string(),
         ),
     );
-    assert_eq!(sender_spl_balance, "0.999999");
+    assert_eq!(
+        sender_spl_balance,
+        TokenAmount {
+            ui_amount: Some(0.999999),
+            decimals: 9,
+            amount: "999999000".to_string(),
+            ui_amount_string: "0.999999".to_string(),
+        }
+    );
     let token_account = setup
         .solana_client
         .get_token_account(&receiver_associated_token_account)
         .unwrap()
         .expect("Missing receiver's associated token account");
     assert_eq!(token_account.token_amount.amount, "1000");
-    let receiver_spl_balance: String = basic_solana.update_call(
+    let receiver_spl_balance: TokenAmount = basic_solana.update_call(
         RECEIVER,
         "get_spl_token_balance",
         (
@@ -227,7 +235,15 @@ fn test_basic_solana() {
             mint_account.to_string(),
         ),
     );
-    assert_eq!(receiver_spl_balance, "0.000001");
+    assert_eq!(
+        receiver_spl_balance,
+        TokenAmount {
+            ui_amount: Some(0.000001),
+            decimals: 9,
+            amount: "1000".to_string(),
+            ui_amount_string: "0.000001".to_string(),
+        }
+    );
 }
 
 pub struct Setup {

--- a/examples/basic_solana/tests/tests.rs
+++ b/examples/basic_solana/tests/tests.rs
@@ -1,15 +1,17 @@
 use basic_solana::{Ed25519KeyName, SolanaNetwork};
-use candid::utils::ArgumentEncoder;
-use candid::{decode_args, encode_args, CandidType, Encode, Nat, Principal};
-use pocket_ic::management_canister::{CanisterId, CanisterSettings};
-use pocket_ic::{PocketIc, PocketIcBuilder};
+use candid::{
+    decode_args, encode_args, utils::ArgumentEncoder, CandidType, Encode, Nat, Principal,
+};
+use pocket_ic::{
+    management_canister::{CanisterId, CanisterSettings},
+    PocketIc, PocketIcBuilder,
+};
 use serde::de::DeserializeOwned;
 use sol_rpc_types::{
     CommitmentLevel, OverrideProvider, RegexSubstitution, RpcAccess, SupportedRpcProvider,
     SupportedRpcProviderId,
 };
-use solana_client::rpc_client::RpcClient as SolanaRpcClient;
-use solana_client::rpc_config::RpcTransactionConfig;
+use solana_client::{rpc_client::RpcClient as SolanaRpcClient, rpc_config::RpcTransactionConfig};
 use solana_commitment_config::CommitmentConfig;
 use solana_hash::Hash;
 use solana_instruction::{AccountMeta, Instruction};
@@ -19,11 +21,7 @@ use solana_pubkey::{pubkey, Pubkey};
 use solana_signature::Signature;
 use solana_signer::Signer;
 use solana_transaction::Transaction;
-use std::env::var;
-use std::path::PathBuf;
-use std::sync::Arc;
-use std::thread;
-use std::time::Duration;
+use std::{env::var, path::PathBuf, sync::Arc, thread, time::Duration};
 
 pub const SENDER: Principal = Principal::from_slice(&[0x9d, 0xf7, 0x42]);
 pub const RECEIVER: Principal = Principal::from_slice(&[0x9d, 0xf7, 0x43]);
@@ -206,7 +204,7 @@ fn test_basic_solana() {
         .unwrap()
         .expect("Missing user's associated token account");
     assert_eq!(token_account.token_amount.amount, "999999000");
-    let sender_spl_balance: Nat = basic_solana.update_call(
+    let sender_spl_balance: String = basic_solana.update_call(
         SENDER,
         "get_spl_token_balance",
         (
@@ -214,14 +212,14 @@ fn test_basic_solana() {
             mint_account.to_string(),
         ),
     );
-    assert_eq!(sender_spl_balance, Nat::from(999_999_000_u64));
+    assert_eq!(sender_spl_balance, "0.999999");
     let token_account = setup
         .solana_client
         .get_token_account(&receiver_associated_token_account)
         .unwrap()
         .expect("Missing receiver's associated token account");
     assert_eq!(token_account.token_amount.amount, "1000");
-    let receiver_spl_balance: Nat = basic_solana.update_call(
+    let receiver_spl_balance: String = basic_solana.update_call(
         RECEIVER,
         "get_spl_token_balance",
         (
@@ -229,7 +227,7 @@ fn test_basic_solana() {
             mint_account.to_string(),
         ),
     );
-    assert_eq!(receiver_spl_balance, Nat::from(1_000_u64));
+    assert_eq!(receiver_spl_balance, "0.000001");
 }
 
 pub struct Setup {

--- a/integration_tests/tests/solana_test_validator.rs
+++ b/integration_tests/tests/solana_test_validator.rs
@@ -309,6 +309,11 @@ async fn should_get_balance() {
     assert_eq!(compare_balances(&setup, publickey).await, 10_000_000_000);
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn should_get_token_account_balance() {
+    // TODO XC-325: Add test for `getTokenAccountBalance` (requires some SPL test infrastructure)
+}
+
 fn solana_rpc_client_get_account(
     pubkey: &Pubkey,
     sol: &RpcClient,

--- a/libs/client/src/lib.rs
+++ b/libs/client/src/lib.rs
@@ -127,7 +127,7 @@ use std::fmt::Debug;
 
 use crate::request::{
     GetAccountInfoRequest, GetBalanceRequest, GetBlockRequest, GetSlotRequest,
-    GetTransactionRequest, JsonRequest, SendTransactionRequest,
+    GetTokenAccountBalanceRequest, GetTransactionRequest, JsonRequest, SendTransactionRequest,
 };
 use async_trait::async_trait;
 use candid::{utils::ArgumentEncoder, CandidType, Principal};
@@ -135,10 +135,11 @@ use ic_cdk::api::call::RejectionCode;
 use serde::de::DeserializeOwned;
 use sol_rpc_types::{
     CommitmentLevel, GetAccountInfoParams, GetBalanceParams, GetBlockParams, GetSlotParams,
-    GetSlotRpcConfig, GetTransactionParams, Lamport, RpcConfig, RpcSources, SendTransactionParams,
-    Signature, SolanaCluster, SupportedRpcProvider, SupportedRpcProviderId, TransactionDetails,
-    TransactionInfo,
+    GetSlotRpcConfig, GetTokenAccountBalanceParams, GetTransactionParams, Lamport, RpcConfig,
+    RpcSources, SendTransactionParams, Signature, SolanaCluster, SupportedRpcProvider,
+    SupportedRpcProviderId, TokenAmount, TransactionDetails, TransactionInfo,
 };
+use solana_account_decoder_client_types::token::UiTokenAmount;
 use solana_clock::Slot;
 use solana_transaction_status_client_types::EncodedConfirmedTransactionWithStatusMeta;
 use std::sync::Arc;
@@ -394,6 +395,61 @@ impl<R> SolRpcClient<R> {
             TransactionDetails::None => 10_000_000_000,
         };
         RequestBuilder::new(self.clone(), GetBlockRequest::new(params), cycles)
+    }
+
+    /// Call `getTokenAccountBalance` on the SOL RPC canister.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use sol_rpc_client::SolRpcClient;
+    /// use sol_rpc_types::{RpcSources, SolanaCluster};
+    /// use solana_pubkey::pubkey;
+    /// use solana_account_decoder_client_types::token::UiTokenAmount;
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # use sol_rpc_types::{MultiRpcResult, TokenAmount};
+    /// let client = SolRpcClient::builder_for_ic()
+    /// #   .with_mocked_response(MultiRpcResult::Consistent(Ok(TokenAmount {
+    /// #       ui_amount: None,
+    /// #       decimals: 0,
+    /// #       amount: "".to_string(),
+    /// #       ui_amount_string: "".to_string(),
+    /// #    })))
+    ///     .with_rpc_sources(RpcSources::Default(SolanaCluster::Mainnet))
+    ///     .build();
+    ///
+    /// let balance = client
+    ///     .get_token_account_balance(pubkey!("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"))
+    ///     .send()
+    ///     .await
+    ///     .expect_consistent();
+    ///
+    /// assert_eq!(balance, Ok(UiTokenAmount {
+    ///     ui_amount: None,
+    ///     decimals: 0,
+    ///     amount: "".to_string(),
+    ///     ui_amount_string: "".to_string(),
+    /// }));
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn get_token_account_balance(
+        &self,
+        params: impl Into<GetTokenAccountBalanceParams>,
+    ) -> RequestBuilder<
+        R,
+        RpcConfig,
+        GetTokenAccountBalanceParams,
+        sol_rpc_types::MultiRpcResult<TokenAmount>,
+        sol_rpc_types::MultiRpcResult<UiTokenAmount>,
+    > {
+        RequestBuilder::new(
+            self.clone(),
+            GetTokenAccountBalanceRequest::new(params.into()),
+            10_000_000_000,
+        )
     }
 
     /// Call `getSlot` on the SOL RPC canister.

--- a/libs/client/src/lib.rs
+++ b/libs/client/src/lib.rs
@@ -412,25 +412,25 @@ impl<R> SolRpcClient<R> {
     /// # use sol_rpc_types::{MultiRpcResult, TokenAmount};
     /// let client = SolRpcClient::builder_for_ic()
     /// #   .with_mocked_response(MultiRpcResult::Consistent(Ok(TokenAmount {
-    /// #       ui_amount: None,
-    /// #       decimals: 0,
-    /// #       amount: "".to_string(),
-    /// #       ui_amount_string: "".to_string(),
+    /// #       ui_amount: Some(251153323.575906),
+    /// #       decimals: 6,
+    /// #       amount: "251153323575906".to_string(),
+    /// #       ui_amount_string: "251153323.575906".to_string(),
     /// #    })))
     ///     .with_rpc_sources(RpcSources::Default(SolanaCluster::Mainnet))
     ///     .build();
     ///
     /// let balance = client
-    ///     .get_token_account_balance(pubkey!("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"))
+    ///     .get_token_account_balance(pubkey!("3emsAVdmGKERbHjmGfQ6oZ1e35dkf5iYcS6U4CPKFVaa"))
     ///     .send()
     ///     .await
     ///     .expect_consistent();
     ///
     /// assert_eq!(balance, Ok(UiTokenAmount {
-    ///     ui_amount: None,
-    ///     decimals: 0,
-    ///     amount: "".to_string(),
-    ///     ui_amount_string: "".to_string(),
+    ///         ui_amount: Some(251153323.575906),
+    ///         decimals: 6,
+    ///         amount: "251153323575906".to_string(),
+    ///         ui_amount_string: "251153323.575906".to_string(),
     /// }));
     /// # Ok(())
     /// # }

--- a/libs/client/src/request/mod.rs
+++ b/libs/client/src/request/mod.rs
@@ -6,9 +6,11 @@ use candid::CandidType;
 use serde::de::DeserializeOwned;
 use sol_rpc_types::{
     AccountInfo, CommitmentLevel, ConfirmedBlock, GetAccountInfoParams, GetBalanceParams,
-    GetBlockCommitmentLevel, GetBlockParams, GetSlotParams, GetSlotRpcConfig, GetTransactionParams,
-    Lamport, RpcConfig, RpcResult, RpcSources, SendTransactionParams, Signature, TransactionInfo,
+    GetBlockCommitmentLevel, GetBlockParams, GetSlotParams, GetSlotRpcConfig,
+    GetTokenAccountBalanceParams, GetTransactionParams, Lamport, RpcConfig, RpcResult, RpcSources,
+    SendTransactionParams, Signature, TokenAmount, TransactionInfo,
 };
+use solana_account_decoder_client_types::token::UiTokenAmount;
 use solana_clock::Slot;
 use solana_transaction_status_client_types::EncodedConfirmedTransactionWithStatusMeta;
 use std::fmt::{Debug, Formatter};
@@ -43,6 +45,8 @@ pub enum SolRpcEndpoint {
     GetBlock,
     /// `getSlot` endpoint.
     GetSlot,
+    /// `getTokenAccountBalance` endpoint.
+    GetTokenAccountBalance,
     /// `getTransaction` endpoint.
     GetTransaction,
     /// `jsonRequest` endpoint.
@@ -59,6 +63,7 @@ impl SolRpcEndpoint {
             SolRpcEndpoint::GetBalance => "getBalance",
             SolRpcEndpoint::GetBlock => "getBlock",
             SolRpcEndpoint::GetSlot => "getSlot",
+            SolRpcEndpoint::GetTokenAccountBalance => "getTokenAccountBalance",
             SolRpcEndpoint::GetTransaction => "getTransaction",
             SolRpcEndpoint::JsonRequest => "jsonRequest",
             SolRpcEndpoint::SendTransaction => "sendTransaction",
@@ -73,6 +78,7 @@ impl SolRpcEndpoint {
             SolRpcEndpoint::GetBlock => "getBlockCyclesCost",
             SolRpcEndpoint::GetSlot => "getSlotCyclesCost",
             SolRpcEndpoint::GetTransaction => "getTransactionCyclesCost",
+            SolRpcEndpoint::GetTokenAccountBalance => "getTokenAccountBalanceCyclesCost",
             SolRpcEndpoint::JsonRequest => "jsonRequestCyclesCost",
             SolRpcEndpoint::SendTransaction => "sendTransactionCyclesCost",
         }
@@ -198,6 +204,32 @@ impl SolRpcRequest for GetSlotRequest {
                 ..Default::default()
             });
         }
+        params
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct GetTokenAccountBalanceRequest(GetTokenAccountBalanceParams);
+
+impl GetTokenAccountBalanceRequest {
+    pub fn new(params: GetTokenAccountBalanceParams) -> Self {
+        Self(params)
+    }
+}
+
+impl SolRpcRequest for GetTokenAccountBalanceRequest {
+    type Config = RpcConfig;
+    type Params = GetTokenAccountBalanceParams;
+    type CandidOutput = sol_rpc_types::MultiRpcResult<TokenAmount>;
+    type Output = sol_rpc_types::MultiRpcResult<UiTokenAmount>;
+
+    fn endpoint(&self) -> SolRpcEndpoint {
+        SolRpcEndpoint::GetTokenAccountBalance
+    }
+
+    fn params(self, default_commitment_level: Option<CommitmentLevel>) -> Self::Params {
+        let mut params = self.0;
+        set_default(default_commitment_level, &mut params.commitment);
         params
     }
 }

--- a/libs/client/src/request/tests.rs
+++ b/libs/client/src/request/tests.rs
@@ -45,6 +45,13 @@ fn should_set_correct_commitment_level() {
                     Some(CommitmentLevel::Confirmed)
                 );
             }
+            SolRpcEndpoint::GetTokenAccountBalance => {
+                let builder = client_with_commitment_level.get_token_account_balance(pubkey);
+                assert_eq!(
+                    builder.request.params.commitment,
+                    Some(CommitmentLevel::Confirmed)
+                );
+            }
             SolRpcEndpoint::GetTransaction => {
                 let builder = client_with_commitment_level.get_transaction("tspfR5p1PFphquz4WzDb7qM4UhJdgQXkEZtW88BykVEdX2zL2kBT9kidwQBviKwQuA3b6GMCR1gknHvzQ3r623T".parse::<Signature>().unwrap());
                 assert_eq!(

--- a/libs/types/src/lib.rs
+++ b/libs/types/src/lib.rs
@@ -20,15 +20,17 @@ pub use solana::{
     account::{AccountData, AccountEncoding, AccountInfo, ParsedAccount},
     request::{
         CommitmentLevel, DataSlice, GetAccountInfoEncoding, GetAccountInfoParams, GetBalanceParams,
-        GetBlockCommitmentLevel, GetBlockParams, GetSlotParams, GetTransactionEncoding,
-        GetTransactionParams, SendTransactionEncoding, SendTransactionParams, TransactionDetails,
+        GetBlockCommitmentLevel, GetBlockParams, GetSlotParams, GetTokenAccountBalanceParams,
+        GetTransactionEncoding, GetTransactionParams, SendTransactionEncoding,
+        SendTransactionParams, TransactionDetails,
     },
     transaction::{
         error::{InstructionError, TransactionError},
         instruction::{CompiledInstruction, InnerInstructions, Instruction},
         reward::{Reward, RewardType},
-        EncodedTransaction, LoadedAddresses, TransactionBinaryEncoding, TransactionInfo,
-        TransactionReturnData, TransactionStatusMeta, TransactionTokenBalance, TransactionVersion,
+        EncodedTransaction, LoadedAddresses, TokenAmount, TransactionBinaryEncoding,
+        TransactionInfo, TransactionReturnData, TransactionStatusMeta, TransactionTokenBalance,
+        TransactionVersion,
     },
     Blockhash, ConfirmedBlock, Lamport, Pubkey, Signature, Slot, Timestamp,
 };

--- a/libs/types/src/response/mod.rs
+++ b/libs/types/src/response/mod.rs
@@ -1,9 +1,10 @@
 use crate::{
-    solana::account::AccountInfo, ConfirmedBlock, RpcResult, RpcSource, Signature, TransactionInfo,
+    solana::account::AccountInfo, ConfirmedBlock, RpcResult, RpcSource, Signature, TokenAmount,
+    TransactionInfo,
 };
 use candid::CandidType;
 use serde::Deserialize;
-use solana_account_decoder_client_types::UiAccount;
+use solana_account_decoder_client_types::{token::UiTokenAmount, UiAccount};
 use solana_transaction_status_client_types::{
     EncodedConfirmedTransactionWithStatusMeta, UiConfirmedBlock,
 };
@@ -135,5 +136,17 @@ impl From<MultiRpcResult<Option<TransactionInfo>>>
 {
     fn from(result: MultiRpcResult<Option<TransactionInfo>>) -> Self {
         result.map(|maybe_transaction| maybe_transaction.map(|transaction| transaction.into()))
+    }
+}
+
+impl From<MultiRpcResult<TokenAmount>> for MultiRpcResult<UiTokenAmount> {
+    fn from(result: MultiRpcResult<TokenAmount>) -> Self {
+        result.map(UiTokenAmount::from)
+    }
+}
+
+impl From<MultiRpcResult<UiTokenAmount>> for MultiRpcResult<TokenAmount> {
+    fn from(result: MultiRpcResult<UiTokenAmount>) -> Self {
+        result.map(TokenAmount::from)
     }
 }

--- a/libs/types/src/solana/request/mod.rs
+++ b/libs/types/src/solana/request/mod.rs
@@ -8,7 +8,7 @@ use serde::Serialize;
 pub struct GetAccountInfoParams {
     /// The public key of the account whose info to fetch formatted as a base-58 string.
     pub pubkey: Pubkey,
-    /// The request returns the slot that has reached this or the default commitment level.
+    /// The commitment describes how finalized a block is at that point in time.
     pub commitment: Option<CommitmentLevel>,
     /// Encoding format for Account data.
     pub encoding: Option<GetAccountInfoEncoding>,
@@ -191,6 +191,24 @@ impl GetSlotParams {
             min_context_slot,
         } = &self;
         commitment.is_none() && min_context_slot.is_none()
+    }
+}
+
+/// The parameters for a Solana [`getTokenAccountBalance`](https://solana.com/docs/rpc/http/gettokenaccountbalance) RPC method call.
+#[derive(Debug, Clone, Default, Deserialize, Serialize, CandidType)]
+pub struct GetTokenAccountBalanceParams {
+    /// The public key of the token account to query formatted as a base-58 string.
+    pub pubkey: Pubkey,
+    /// The commitment describes how finalized a block is at that point in time.
+    pub commitment: Option<CommitmentLevel>,
+}
+
+impl From<solana_pubkey::Pubkey> for GetTokenAccountBalanceParams {
+    fn from(pubkey: solana_pubkey::Pubkey) -> Self {
+        Self {
+            pubkey: pubkey.to_string(),
+            commitment: None,
+        }
     }
 }
 


### PR DESCRIPTION
(XC-325) Add support for the `getTokenAccountBalance` Solana RPC method.