### PR TITLE
test: use default commitment for client in `solana_test_validator.rs`

### DIFF
--- a/integration_tests/tests/solana_test_validator.rs
+++ b/integration_tests/tests/solana_test_validator.rs
@@ -8,8 +8,8 @@ use sol_rpc_client::SolRpcClient;
 use sol_rpc_int_tests::{spl, PocketIcLiveModeRuntime};
 use sol_rpc_types::{
     CommitmentLevel, GetAccountInfoEncoding, GetAccountInfoParams, GetBlockCommitmentLevel,
-    GetBlockParams, GetSlotParams, GetTransactionEncoding, GetTransactionParams, InstallArgs,
-    Lamport, OverrideProvider, RegexSubstitution, SendTransactionParams, TransactionDetails,
+    GetBlockParams, GetTransactionEncoding, GetTransactionParams, InstallArgs, Lamport,
+    OverrideProvider, RegexSubstitution, TransactionDetails,
 };
 use solana_account_decoder_client_types::{token::UiTokenAmount, UiAccount};
 use solana_client::rpc_client::{RpcClient as SolanaRpcClient, RpcClient};

--- a/integration_tests/tests/solana_test_validator.rs
+++ b/integration_tests/tests/solana_test_validator.rs
@@ -186,7 +186,7 @@ async fn should_get_transaction() {
                     &signature,
                     RpcTransactionConfig {
                         encoding: Some(UiTransactionEncoding::Base64),
-                        commitment: None,
+                        commitment: Some(CommitmentConfig::confirmed()),
                         max_supported_transaction_version: None,
                     },
                 )


### PR DESCRIPTION
(XC-291) Leverage `ClientBuilder::with_default_commitment` to avoid having to specify the commitment level in all request parameters in `solana_test_validator.rs`.