### PR TITLE
refactor: Serialize `VecWithMaxLen` properly

### DIFF
--- a/libs/types/src/lib.rs
+++ b/libs/types/src/lib.rs
@@ -44,10 +44,10 @@ pub use solana::{
 
 /// A vector with a maximum capacity.
 #[derive(Debug, Clone, Deserialize, Serialize, CandidType, PartialEq, Default, Into)]
-#[serde(try_from = "Vec<T>")]
-pub struct VecWithMaxLen<T, const CAPACITY: usize>(Vec<T>);
+#[serde(try_from = "Vec<T>", into = "Vec<T>")]
+pub struct VecWithMaxLen<T: Clone, const CAPACITY: usize>(Vec<T>);
 
-impl<T, const CAPACITY: usize> TryFrom<Vec<T>> for VecWithMaxLen<T, CAPACITY> {
+impl<T: Clone, const CAPACITY: usize> TryFrom<Vec<T>> for VecWithMaxLen<T, CAPACITY> {
     type Error = RpcError;
 
     fn try_from(value: Vec<T>) -> Result<Self, Self::Error> {

--- a/libs/types/src/lib.rs
+++ b/libs/types/src/lib.rs
@@ -21,7 +21,7 @@ pub use rpc_client::{
     RegexSubstitution, RoundingError, RpcAccess, RpcAuth, RpcConfig, RpcEndpoint, RpcError,
     RpcResult, RpcSource, RpcSources, SolanaCluster, SupportedRpcProvider, SupportedRpcProviderId,
 };
-use serde::Serialize;
+use serde::{Serialize, Serializer};
 pub use solana::{
     account::{AccountData, AccountEncoding, AccountInfo, ParsedAccount},
     request::{
@@ -43,11 +43,11 @@ pub use solana::{
 };
 
 /// A vector with a maximum capacity.
-#[derive(Debug, Clone, Deserialize, Serialize, CandidType, PartialEq, Default, Into)]
-#[serde(try_from = "Vec<T>", into = "Vec<T>")]
-pub struct VecWithMaxLen<T: Clone, const CAPACITY: usize>(Vec<T>);
+#[derive(Debug, Clone, Deserialize, CandidType, PartialEq, Default, Into)]
+#[serde(try_from = "Vec<T>")]
+pub struct VecWithMaxLen<T, const CAPACITY: usize>(Vec<T>);
 
-impl<T: Clone, const CAPACITY: usize> TryFrom<Vec<T>> for VecWithMaxLen<T, CAPACITY> {
+impl<T, const CAPACITY: usize> TryFrom<Vec<T>> for VecWithMaxLen<T, CAPACITY> {
     type Error = RpcError;
 
     fn try_from(value: Vec<T>) -> Result<Self, Self::Error> {
@@ -58,5 +58,14 @@ impl<T: Clone, const CAPACITY: usize> TryFrom<Vec<T>> for VecWithMaxLen<T, CAPAC
             )));
         }
         Ok(Self(value))
+    }
+}
+
+impl<T: Serialize, const CAPACITY: usize> Serialize for VecWithMaxLen<T, CAPACITY> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.0.serialize(serializer)
     }
 }

--- a/libs/types/src/tests.rs
+++ b/libs/types/src/tests.rs
@@ -1,12 +1,9 @@
 use crate::VecWithMaxLen;
 use candid::{CandidType, Decode, Encode};
-use proptest::arbitrary::Arbitrary;
-use proptest::prelude::any;
-use proptest::prelude::TestCaseError;
-use proptest::prop_assert;
 use proptest::{
-    prelude::{prop, Strategy},
-    prop_assert_eq, proptest,
+    arbitrary::Arbitrary,
+    prelude::{any, prop, Strategy, TestCaseError},
+    prop_assert, prop_assert_eq, proptest,
 };
 use serde::de::DeserializeOwned;
 

--- a/libs/types/src/tests.rs
+++ b/libs/types/src/tests.rs
@@ -1,48 +1,87 @@
 use crate::VecWithMaxLen;
-use candid::{Decode, Encode};
+use candid::{CandidType, Decode, Encode};
+use proptest::arbitrary::Arbitrary;
+use proptest::prelude::any;
+use proptest::prelude::TestCaseError;
+use proptest::prop_assert;
 use proptest::{
-    arbitrary::any,
     prelude::{prop, Strategy},
-    proptest,
+    prop_assert_eq, proptest,
 };
-use serde::Deserialize;
-use serde_json::json;
+use serde::de::DeserializeOwned;
 
-proptest! {
-    #[test]
-    fn should_encode_decode (values in arb_vec_with_capacity()) {
-        let encoded = Encode!(&values).unwrap();
-        let decoded = Decode!(&encoded, VecWithMaxLen::<String, 100>).unwrap();
+mod vec_with_max_len_tests {
+    use super::*;
 
-        assert_eq!(decoded, values);
+    proptest! {
+        #[test]
+        fn should_encode_decode (
+            string_vec in arb_vec_with_max_size(50),
+            int_vec in arb_vec_with_max_size(75),
+            bytes_vec in arb_vec_with_max_size(100))
+        {
+            encode_decode_roundtrip::<String, 50>(string_vec)?;
+            encode_decode_roundtrip::<i32, 75>(int_vec)?;
+            encode_decode_roundtrip::<Vec<u8>, 100>(bytes_vec)?;
+        }
+
+        #[test]
+        fn should_fail_to_decode_when_too_long(
+            string_vec in arb_vec_with_min_size(50),
+            int_vec in arb_vec_with_min_size(75),
+            bytes_vec in arb_vec_with_min_size(100))
+        {
+            expect_decoding_error::<String, 50>(string_vec)?;
+            expect_decoding_error::<i32, 75>(int_vec)?;
+            expect_decoding_error::<Vec<u8>, 100>(bytes_vec)?;
+        }
     }
 
-    #[test]
-    fn should_deserialize(values in prop::collection::vec(any::<String>(), 0..=100)) {
-        let serialized = json!(values);
-
-        let result = VecWithMaxLen::<String, 100>::deserialize(&serialized);
-
-        assert!(result.is_ok());
-        assert_eq!(Vec::from(result.unwrap()), values);
-    }
-
-    #[test]
-    fn should_not_deserialize(values in prop::collection::vec(any::<String>(), 101..1000)) {
-        let serialized = json!(values);
-
-        let result = VecWithMaxLen::<String, 100>::deserialize(&serialized);
-
-        assert!(result.is_err());
-        assert_eq!(
-            result.err().unwrap().to_string(),
-            format!("Validation error: Expected at most 100 items, but got {}", values.len())
+    fn encode_decode_roundtrip<T, const CAPACITY: usize>(value: Vec<T>) -> Result<(), TestCaseError>
+    where
+        T: Clone + CandidType + std::fmt::Debug + PartialEq + DeserializeOwned,
+    {
+        let parsed_value: VecWithMaxLen<T, CAPACITY> = TryFrom::try_from(value.clone())?;
+        let encoded_value = Encode!(&value)?;
+        let encoded_parsed_value = Encode!(&parsed_value)?;
+        prop_assert_eq!(
+            &encoded_value,
+            &encoded_parsed_value,
+            "Encoded value differ for {:?}",
+            value
         );
-    }
-}
 
-fn arb_vec_with_capacity<const CAPACITY: usize>(
-) -> impl Strategy<Value = VecWithMaxLen<String, CAPACITY>> {
-    prop::collection::vec(any::<String>(), 0..=CAPACITY)
-        .prop_map(|values| values.try_into().unwrap())
+        let decoded_text_value = Decode!(&encoded_value, VecWithMaxLen<T, CAPACITY>)?;
+        prop_assert_eq!(
+            &decoded_text_value,
+            &parsed_value,
+            "Decoded value differ for {:?}",
+            value
+        );
+        Ok(())
+    }
+
+    fn expect_decoding_error<T, const CAPACITY: usize>(
+        too_long: Vec<T>,
+    ) -> Result<(), TestCaseError>
+    where
+        T: Clone + CandidType + std::fmt::Debug + PartialEq + DeserializeOwned,
+    {
+        let result = Decode!(&Encode!(&too_long)?, VecWithMaxLen<T, CAPACITY>);
+        prop_assert!(
+            result.is_err(),
+            "Expected error decoding {:?}, got: {:?}",
+            too_long,
+            result
+        );
+        Ok(())
+    }
+
+    fn arb_vec_with_max_size<T: Arbitrary>(max_size: usize) -> impl Strategy<Value = Vec<T>> {
+        prop::collection::vec(any::<T>(), 0..=max_size)
+    }
+
+    fn arb_vec_with_min_size<T: Arbitrary>(min_size: usize) -> impl Strategy<Value = Vec<T>> {
+        prop::collection::vec(any::<T>(), min_size + 1..=min_size + 100)
+    }
 }

--- a/libs/types/src/tests.rs
+++ b/libs/types/src/tests.rs
@@ -24,9 +24,9 @@ mod vec_with_max_len_tests {
 
         #[test]
         fn should_fail_to_decode_when_too_long(
-            string_vec in arb_vec_with_min_size(50),
-            int_vec in arb_vec_with_min_size(75),
-            bytes_vec in arb_vec_with_min_size(100))
+            string_vec in arb_vec_with_size_greater_than(50),
+            int_vec in arb_vec_with_size_greater_than(75),
+            bytes_vec in arb_vec_with_size_greater_than(100))
         {
             expect_decoding_error::<String, 50>(string_vec)?;
             expect_decoding_error::<i32, 75>(int_vec)?;
@@ -38,20 +38,20 @@ mod vec_with_max_len_tests {
     where
         T: Clone + CandidType + std::fmt::Debug + PartialEq + DeserializeOwned,
     {
-        let parsed_value: VecWithMaxLen<T, CAPACITY> = TryFrom::try_from(value.clone())?;
+        let wrapped_value: VecWithMaxLen<T, CAPACITY> = TryFrom::try_from(value.clone())?;
         let encoded_value = Encode!(&value)?;
-        let encoded_parsed_value = Encode!(&parsed_value)?;
+        let encoded_wrapped_value = Encode!(&wrapped_value)?;
         prop_assert_eq!(
             &encoded_value,
-            &encoded_parsed_value,
+            &encoded_wrapped_value,
             "Encoded value differ for {:?}",
             value
         );
 
-        let decoded_text_value = Decode!(&encoded_value, VecWithMaxLen<T, CAPACITY>)?;
+        let decoded_value = Decode!(&encoded_value, VecWithMaxLen<T, CAPACITY>)?;
         prop_assert_eq!(
-            &decoded_text_value,
-            &parsed_value,
+            &decoded_value,
+            &wrapped_value,
             "Decoded value differ for {:?}",
             value
         );
@@ -78,7 +78,7 @@ mod vec_with_max_len_tests {
         prop::collection::vec(any::<T>(), 0..=max_size)
     }
 
-    fn arb_vec_with_min_size<T: Arbitrary>(min_size: usize) -> impl Strategy<Value = Vec<T>> {
+    fn arb_vec_with_size_greater_than<T: Arbitrary>(min_size: usize) -> impl Strategy<Value = Vec<T>> {
         prop::collection::vec(any::<T>(), min_size + 1..=min_size + 100)
     }
 }

--- a/libs/types/src/tests.rs
+++ b/libs/types/src/tests.rs
@@ -78,7 +78,9 @@ mod vec_with_max_len_tests {
         prop::collection::vec(any::<T>(), 0..=max_size)
     }
 
-    fn arb_vec_with_size_greater_than<T: Arbitrary>(min_size: usize) -> impl Strategy<Value = Vec<T>> {
+    fn arb_vec_with_size_greater_than<T: Arbitrary>(
+        min_size: usize,
+    ) -> impl Strategy<Value = Vec<T>> {
         prop::collection::vec(any::<T>(), min_size + 1..=min_size + 100)
     }
 }


### PR DESCRIPTION
(XC-291) Serialize the new `VecWithMaxLen` type to `Vec` (i.e. add `#[serde(into = "Vec<T>")]` annotation to type) and add some unit tests to ensure encoding/decoding round trips with Candid are successful when expected or fail when the underlying data is too long.