### PR TITLE
docs: hide setup in method documentation

### DIFF
--- a/libs/client/src/lib.rs
+++ b/libs/client/src/lib.rs
@@ -301,7 +301,7 @@ impl<R> SolRpcClient<R> {
     /// # use sol_rpc_client::fixtures::usdc_account;
     /// # use sol_rpc_types::{AccountData, AccountEncoding, AccountInfo, MultiRpcResult};
     /// let client = SolRpcClient::builder_for_ic()
-    ///     .with_mocked_response(MultiRpcResult::Consistent(Ok(Some(usdc_account()))))
+    /// #   .with_mocked_response(MultiRpcResult::Consistent(Ok(Some(usdc_account()))))
     ///     .with_rpc_sources(RpcSources::Default(SolanaCluster::Mainnet))
     ///     .build();
     ///


### PR DESCRIPTION
Hide the mock response setup in the documentation for the SOL RPC client `get_account_info` method.