### PR TITLE
chore: add Chainstack RPC provider

### DIFF
--- a/canister/scripts/provision.sh
+++ b/canister/scripts/provision.sh
@@ -7,6 +7,7 @@ set -e -x
 set -u # or set -o nounset
 : "$ALCHEMY_API_KEY"
 : "$ANKR_API_KEY"
+: "$CHAINSTACK_API_KEY"
 : "$DRPC_API_KEY"
 : "$HELIUS_API_KEY"
 
@@ -21,6 +22,8 @@ dfx canister call ${CANISTER} updateApiKeys "(vec {
   record { variant { AlchemyDevnet }; opt \"${ALCHEMY_API_KEY}\" };
   record { variant { AnkrMainnet }; opt \"${ANKR_API_KEY}\" };
   record { variant { AnkrDevnet }; opt \"${ANKR_API_KEY}\" };
+  record { variant { ChainstackMainnet }; opt \"${ANKR_API_KEY}\" };
+  record { variant { ChainstackDevnet }; opt \"${ANKR_API_KEY}\" };
   record { variant { DrpcMainnet }; opt \"${DRPC_API_KEY}\" };
   record { variant { DrpcDevnet }; opt \"${DRPC_API_KEY}\" };
   record { variant { HeliusMainnet }; opt \"${HELIUS_API_KEY}\" };

--- a/canister/scripts/provision.sh
+++ b/canister/scripts/provision.sh
@@ -22,8 +22,8 @@ dfx canister call ${CANISTER} updateApiKeys "(vec {
   record { variant { AlchemyDevnet }; opt \"${ALCHEMY_API_KEY}\" };
   record { variant { AnkrMainnet }; opt \"${ANKR_API_KEY}\" };
   record { variant { AnkrDevnet }; opt \"${ANKR_API_KEY}\" };
-  record { variant { ChainstackMainnet }; opt \"${ANKR_API_KEY}\" };
-  record { variant { ChainstackDevnet }; opt \"${ANKR_API_KEY}\" };
+  record { variant { ChainstackMainnet }; opt \"${CHAINSTACK_API_KEY}\" };
+  record { variant { ChainstackDevnet }; opt \"${CHAINSTACK_API_KEY}\" };
   record { variant { DrpcMainnet }; opt \"${DRPC_API_KEY}\" };
   record { variant { DrpcDevnet }; opt \"${DRPC_API_KEY}\" };
   record { variant { HeliusMainnet }; opt \"${HELIUS_API_KEY}\" };

--- a/canister/sol_rpc_canister.did
+++ b/canister/sol_rpc_canister.did
@@ -14,6 +14,8 @@ type SupportedProvider = variant {
   AlchemyDevnet;
   AnkrMainnet;
   AnkrDevnet;
+  ChainstackMainnet;
+  ChainstackDevnet;
   DrpcMainnet;
   DrpcDevnet;
   HeliusMainnet;

--- a/canister/src/providers/mod.rs
+++ b/canister/src/providers/mod.rs
@@ -48,6 +48,24 @@ thread_local! {
                 public_url: Some("https://rpc.ankr.com/solana_devnet/".to_string()),
             }
         },
+        SupportedRpcProviderId::ChainstackMainnet => SupportedRpcProvider {
+            cluster: SolanaCluster::Mainnet,
+            access: RpcAccess::Authenticated {
+                auth: RpcAuth::UrlParameter {
+                    url_pattern: "https://solana-mainnet.core.chainstack.com/{API_KEY}".to_string(),
+                },
+                public_url: None,
+            }
+        },
+        SupportedRpcProviderId::ChainstackDevnet => SupportedRpcProvider {
+            cluster: SolanaCluster::Devnet,
+            access: RpcAccess::Authenticated {
+                auth: RpcAuth::UrlParameter {
+                    url_pattern: "https://solana-devnet.core.chainstack.com/{API_KEY}".to_string(),
+                },
+                public_url: None,
+            }
+        },
         SupportedRpcProviderId::DrpcMainnet => SupportedRpcProvider {
             cluster: SolanaCluster::Mainnet,
             access: RpcAccess::Authenticated {
@@ -116,6 +134,7 @@ impl Providers {
     const NON_DEFAULT_MAINNET_SUPPORTED_PROVIDERS: &'static [SupportedRpcProviderId] = &[
         SupportedRpcProviderId::AnkrMainnet,
         SupportedRpcProviderId::PublicNodeMainnet,
+        SupportedRpcProviderId::ChainstackMainnet,
     ];
 
     const DEFAULT_DEVNET_SUPPORTED_PROVIDERS: &'static [SupportedRpcProviderId] = &[
@@ -123,8 +142,10 @@ impl Providers {
         SupportedRpcProviderId::HeliusDevnet,
         SupportedRpcProviderId::DrpcDevnet,
     ];
-    const NON_DEFAULT_DEVNET_SUPPORTED_PROVIDERS: &'static [SupportedRpcProviderId] =
-        &[SupportedRpcProviderId::AnkrDevnet];
+    const NON_DEFAULT_DEVNET_SUPPORTED_PROVIDERS: &'static [SupportedRpcProviderId] = &[
+        SupportedRpcProviderId::AnkrDevnet,
+        SupportedRpcProviderId::ChainstackDevnet,
+    ];
 
     pub fn new(source: RpcSources, strategy: ConsensusStrategy) -> Result<Self, ProviderError> {
         fn get_sources(provider_ids: &[SupportedRpcProviderId]) -> Vec<RpcSource> {

--- a/integration_tests/tests/tests.rs
+++ b/integration_tests/tests/tests.rs
@@ -133,7 +133,7 @@ mod get_provider_tests {
         let client = setup.client().build();
         let providers = client.get_providers().await;
 
-        assert_eq!(providers.len(), 9);
+        assert_eq!(providers.len(), 10);
 
         assert_eq!(
             providers[0],

--- a/integration_tests/tests/tests.rs
+++ b/integration_tests/tests/tests.rs
@@ -133,7 +133,7 @@ mod get_provider_tests {
         let client = setup.client().build();
         let providers = client.get_providers().await;
 
-        assert_eq!(providers.len(), 10);
+        assert_eq!(providers.len(), 11);
 
         assert_eq!(
             providers[0],

--- a/libs/types/src/rpc_client/mod.rs
+++ b/libs/types/src/rpc_client/mod.rs
@@ -321,6 +321,10 @@ pub enum SupportedRpcProviderId {
     AnkrMainnet,
     /// [Ankr](https://www.ankr.com/) provider on [Solana Devnet](https://solana.com/docs/references/clusters)
     AnkrDevnet,
+    /// [Chainstack](https://www.chainstack.com/) provider on [Solana Mainnet](https://solana.com/docs/references/clusters)
+    ChainstackMainnet,
+    /// [Chainstack](https://www.chainstack.com/) provider on [Solana Devnet](https://solana.com/docs/references/clusters)
+    ChainstackDevnet,
     /// [dRPC](https://drpc.org/) provider on [Solana Mainnet](https://solana.com/docs/references/clusters)
     DrpcMainnet,
     /// [dRPC](https://drpc.org/) provider on [Solana Devnet](https://solana.com/docs/references/clusters)


### PR DESCRIPTION
(XC-354) Add Chainstack as a supported RPC provider for both Mainnet ande Devnet. It is currently a non-default provider for both Solana clusters.