### PR TITLE
chore: add Tatum RPC provider

### DIFF
--- a/canister/scripts/provision.sh
+++ b/canister/scripts/provision.sh
@@ -7,6 +7,7 @@ set -e -x
 set -u # or set -o nounset
 : "$ALCHEMY_API_KEY"
 : "$ANKR_API_KEY"
+: "$TATUM_API_KEY"
 : "$DRPC_API_KEY"
 : "$HELIUS_API_KEY"
 
@@ -21,6 +22,8 @@ dfx canister call ${CANISTER} updateApiKeys "(vec {
   record { variant { AlchemyDevnet }; opt \"${ALCHEMY_API_KEY}\" };
   record { variant { AnkrMainnet }; opt \"${ANKR_API_KEY}\" };
   record { variant { AnkrDevnet }; opt \"${ANKR_API_KEY}\" };
+  record { variant { TatumMainnet }; opt \"${TATUM_API_KEY}\" };
+  record { variant { TatumDevnet }; opt \"${TATUM_API_KEY}\" };
   record { variant { DrpcMainnet }; opt \"${DRPC_API_KEY}\" };
   record { variant { DrpcDevnet }; opt \"${DRPC_API_KEY}\" };
   record { variant { HeliusMainnet }; opt \"${HELIUS_API_KEY}\" };

--- a/canister/sol_rpc_canister.did
+++ b/canister/sol_rpc_canister.did
@@ -14,6 +14,8 @@ type SupportedProvider = variant {
   AlchemyDevnet;
   AnkrMainnet;
   AnkrDevnet;
+  TatumMainnet;
+  TatumDevnet;
   DrpcMainnet;
   DrpcDevnet;
   HeliusMainnet;

--- a/canister/src/candid_rpc/mod.rs
+++ b/canister/src/candid_rpc/mod.rs
@@ -67,7 +67,7 @@ fn process_error<T, E: Into<RpcError>>(error: E) -> MultiRpcResult<T> {
 pub fn hostname(provider: SupportedRpcProvider) -> Option<String> {
     let url = match provider.access {
         RpcAccess::Authenticated { auth, .. } => match auth {
-            RpcAuth::BearerToken { url } => url,
+            RpcAuth::BearerToken { url } | RpcAuth::CustomHeader { url, .. } => url,
             RpcAuth::UrlParameter { url_pattern } => url_pattern,
         },
         RpcAccess::Unauthenticated { public_url } => public_url,

--- a/canister/src/providers/mod.rs
+++ b/canister/src/providers/mod.rs
@@ -48,6 +48,26 @@ thread_local! {
                 public_url: Some("https://rpc.ankr.com/solana_devnet/".to_string()),
             }
         },
+        SupportedRpcProviderId::TatumMainnet => SupportedRpcProvider {
+            cluster: SolanaCluster::Mainnet,
+            access: RpcAccess::Authenticated {
+                auth: RpcAuth::CustomHeader {
+                    header_name: "x-api-key".to_string(),
+                    url: "https://solana-mainnet.gateway.tatum.io/".to_string(),
+                },
+                public_url: None,
+            }
+        },
+        SupportedRpcProviderId::TatumDevnet => SupportedRpcProvider {
+            cluster: SolanaCluster::Devnet,
+            access: RpcAccess::Authenticated {
+                auth: RpcAuth::CustomHeader {
+                    header_name: "x-api-key".to_string(),
+                    url: "https://solana-devnet.gateway.tatum.io/".to_string(),
+                },
+                public_url: None,
+            }
+        },
         SupportedRpcProviderId::DrpcMainnet => SupportedRpcProvider {
             cluster: SolanaCluster::Mainnet,
             access: RpcAccess::Authenticated {
@@ -116,6 +136,7 @@ impl Providers {
     const NON_DEFAULT_MAINNET_SUPPORTED_PROVIDERS: &'static [SupportedRpcProviderId] = &[
         SupportedRpcProviderId::AnkrMainnet,
         SupportedRpcProviderId::PublicNodeMainnet,
+        SupportedRpcProviderId::TatumMainnet,
     ];
 
     const DEFAULT_DEVNET_SUPPORTED_PROVIDERS: &'static [SupportedRpcProviderId] = &[
@@ -123,8 +144,10 @@ impl Providers {
         SupportedRpcProviderId::HeliusDevnet,
         SupportedRpcProviderId::DrpcDevnet,
     ];
-    const NON_DEFAULT_DEVNET_SUPPORTED_PROVIDERS: &'static [SupportedRpcProviderId] =
-        &[SupportedRpcProviderId::AnkrDevnet];
+    const NON_DEFAULT_DEVNET_SUPPORTED_PROVIDERS: &'static [SupportedRpcProviderId] = &[
+        SupportedRpcProviderId::AnkrDevnet,
+        SupportedRpcProviderId::TatumDevnet,
+    ];
 
     pub fn new(source: RpcSources, strategy: ConsensusStrategy) -> Result<Self, ProviderError> {
         fn get_sources(provider_ids: &[SupportedRpcProviderId]) -> Vec<RpcSource> {
@@ -258,6 +281,13 @@ fn resolve_api_key(access: RpcAccess, provider: SupportedRpcProviderId) -> RpcEn
                         url: url.to_string(),
                         headers: Some(vec![HttpHeader {
                             name: "Authorization".to_string(),
+                            value: format!("Bearer {}", api_key.read()),
+                        }]),
+                    },
+                    RpcAuth::CustomHeader { header_name, url } => RpcEndpoint {
+                        url: url.to_string(),
+                        headers: Some(vec![HttpHeader {
+                            name: header_name.to_string(),
                             value: format!("Bearer {}", api_key.read()),
                         }]),
                     },

--- a/canister/src/providers/tests.rs
+++ b/canister/src/providers/tests.rs
@@ -23,7 +23,9 @@ fn test_rpc_provider_url_patterns() {
             match access {
                 RpcAccess::Authenticated { auth, public_url } => {
                     match auth {
-                        RpcAuth::BearerToken { url } => assert_not_url_pattern(url, provider),
+                        RpcAuth::BearerToken { url } | RpcAuth::CustomHeader { url, .. } => {
+                            assert_not_url_pattern(url, provider)
+                        }
                         RpcAuth::UrlParameter { url_pattern } => {
                             assert_url_pattern(url_pattern, provider)
                         }

--- a/integration_tests/tests/tests.rs
+++ b/integration_tests/tests/tests.rs
@@ -133,7 +133,7 @@ mod get_provider_tests {
         let client = setup.client().build();
         let providers = client.get_providers().await;
 
-        assert_eq!(providers.len(), 9);
+        assert_eq!(providers.len(), 11);
 
         assert_eq!(
             providers[0],

--- a/libs/types/src/rpc_client/mod.rs
+++ b/libs/types/src/rpc_client/mod.rs
@@ -82,7 +82,8 @@ pub enum HttpOutcallError {
     /// Response is not a valid JSON-RPC response,
     /// which means that the response was not successful (status other than 2xx)
     /// or that the response body could not be deserialized into a JSON-RPC response.
-    #[error("Invalid HTTP JSON-RPC response: status {status}, body: {body}, parsing error: {parsing_error:?}")]
+    #[error("Invalid HTTP JSON-RPC response: status {status}, body: {body}, parsing error: {parsing_error:?}"
+    )]
     InvalidHttpJsonRpcResponse {
         /// The HTTP status code returned.
         status: u16,
@@ -321,6 +322,10 @@ pub enum SupportedRpcProviderId {
     AnkrMainnet,
     /// [Ankr](https://www.ankr.com/) provider on [Solana Devnet](https://solana.com/docs/references/clusters)
     AnkrDevnet,
+    /// [Tatum](https://www.chainstack.com/) provider on [Solana Mainnet](https://solana.com/docs/references/clusters)
+    TatumMainnet,
+    /// [Tatum](https://www.chainstack.com/) provider on [Solana Devnet](https://solana.com/docs/references/clusters)
+    TatumDevnet,
     /// [dRPC](https://drpc.org/) provider on [Solana Mainnet](https://solana.com/docs/references/clusters)
     DrpcMainnet,
     /// [dRPC](https://drpc.org/) provider on [Solana Devnet](https://solana.com/docs/references/clusters)
@@ -398,6 +403,13 @@ pub enum RpcAuth {
     /// API key will be used in an Authorization header as Bearer token, e.g.,
     /// `Authorization: Bearer API_KEY`
     BearerToken {
+        /// Request URL for the provider.
+        url: String,
+    },
+    /// API key will be used in a custom header, e.g. `X-Api-Key: API_KEY`
+    CustomHeader {
+        /// Name of the header in which the API key is placed.
+        header_name: String,
         /// Request URL for the provider.
         url: String,
     },


### PR DESCRIPTION
(XC-354) Add Tatum as a supported RPC provider for both Mainnet ande Devnet. It is currently a non-default provider for both Solana clusters.