### PR TITLE
test: durable nonce end-to-end test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,5 @@ jobs:
 
       - name: "Run end-to-end tests"
         env:
-          SOLANA_RECEIVER_PUBLIC_KEY: "rcvXBuRWbcXAPAWG6VgnjbehGPyLYqdfBHXL2L4XVCt"
           DFX_DEPLOY_KEY: ${{ secrets.DFX_DEPLOY_KEY }}
         run: cargo test --locked --package sol_rpc_e2e_tests -- --test-threads 2 --nocapture

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,4 +178,4 @@ jobs:
       - name: "Run end-to-end tests"
         env:
           DFX_DEPLOY_KEY: ${{ secrets.DFX_DEPLOY_KEY }}
-        run: cargo test --locked --package sol_rpc_e2e_tests -- --test-threads 2 --nocapture
+        run: cargo test --locked --package sol_rpc_e2e_tests -- --test-threads 1 --nocapture

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4524,6 +4524,7 @@ dependencies = [
  "solana-pubkey",
  "solana-signature",
  "solana-transaction",
+ "solana-transaction-status-client-types",
  "tokio",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4516,6 +4516,7 @@ dependencies = [
  "sol_rpc_client",
  "sol_rpc_int_tests",
  "sol_rpc_types",
+ "solana-client",
  "solana-commitment-config",
  "solana-compute-budget-interface",
  "solana-hash",

--- a/end_to_end_tests/Cargo.toml
+++ b/end_to_end_tests/Cargo.toml
@@ -24,6 +24,7 @@ solana-pubkey = { workspace = true }
 solana-signature = { workspace = true }
 solana-transaction = { workspace = true }
 solana-transaction-status-client-types = { workspace = true }
+solana-client = { workspace = true }
 tokio = { workspace = true }
 
 [dev-dependencies]

--- a/end_to_end_tests/Cargo.toml
+++ b/end_to_end_tests/Cargo.toml
@@ -23,6 +23,7 @@ solana-message = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-signature = { workspace = true }
 solana-transaction = { workspace = true }
+solana-transaction-status-client-types = { workspace = true }
 tokio = { workspace = true }
 
 [dev-dependencies]

--- a/end_to_end_tests/src/lib.rs
+++ b/end_to_end_tests/src/lib.rs
@@ -143,38 +143,6 @@ impl Setup {
             .expect_consistent()
             .unwrap_or_else(|_| panic!("Failed to fetch account balance for account {pubkey}"))
     }
-
-    pub async fn get_transaction_fee(&self, transaction_id: &Signature, slot: u64) -> u64 {
-        let block = self
-            .client()
-            .get_block(slot)
-            .send()
-            .await
-            .expect_consistent()
-            .expect("Call to `getBlock` failed`")
-            .unwrap_or_else(|| panic!("No block found for slot {:?}", slot));
-        let transaction_fees = block
-            .transactions
-            .expect("Block has no transactions")
-            .into_iter()
-            .find(|transaction| {
-                transaction
-                    .transaction
-                    .decode()
-                    .expect("Failed to decode transaction")
-                    .signatures
-                    .first()
-                    == Some(transaction_id)
-            })
-            .map(|transaction| transaction.meta.expect("Transaction has no metadata").fee)
-            .unwrap_or_else(|| {
-                panic!(
-                    "Unable to get transaction fee for transaction '{:?}' from block '{:?}'",
-                    transaction_id, block.blockhash
-                )
-            });
-        transaction_fees
-    }
 }
 
 impl Default for Setup {

--- a/end_to_end_tests/src/lib.rs
+++ b/end_to_end_tests/src/lib.rs
@@ -166,7 +166,7 @@ impl Setup {
             0
         } else {
             prioritization_fees[prioritization_fees.len() / 2]
-        };
+        }
     }
 }
 

--- a/end_to_end_tests/src/lib.rs
+++ b/end_to_end_tests/src/lib.rs
@@ -143,6 +143,31 @@ impl Setup {
             .expect_consistent()
             .unwrap_or_else(|_| panic!("Failed to fetch account balance for account {pubkey}"))
     }
+
+    pub async fn get_median_recent_prioritization_fees(
+        &self,
+        sender_pubkey: &Pubkey,
+        recipient_pubkey: &Pubkey,
+    ) -> u64 {
+        let mut prioritization_fees: Vec<_> = self
+            .client()
+            .get_recent_prioritization_fees([sender_pubkey, recipient_pubkey])
+            .unwrap()
+            .send()
+            .await
+            .expect_consistent()
+            .expect("Call to `getRecentPrioritizationFees` failed")
+            .into_iter()
+            .map(|fee| fee.prioritization_fee)
+            .collect();
+        prioritization_fees.sort();
+
+        if prioritization_fees.is_empty() {
+            0
+        } else {
+            prioritization_fees[prioritization_fees.len() / 2]
+        };
+    }
 }
 
 impl Default for Setup {

--- a/end_to_end_tests/src/lib.rs
+++ b/end_to_end_tests/src/lib.rs
@@ -89,7 +89,7 @@ impl Setup {
                     if let Some(err) = &status.err {
                         panic!("Transaction failed with error {:?}", err);
                     }
-                    if status.satisfies_commitment(CommitmentConfig::confirmed()) {
+                    if status.satisfies_commitment(CommitmentConfig::finalized()) {
                         return;
                     }
                 }

--- a/end_to_end_tests/src/lib.rs
+++ b/end_to_end_tests/src/lib.rs
@@ -142,7 +142,7 @@ impl Setup {
                 .expect("Failed to request airdrop");
             self.solana_client.wait_for_balance_with_commitment(
                 account,
-                Some(amount),
+                Some(balance + amount),
                 CommitmentConfig::confirmed(),
             );
         }

--- a/end_to_end_tests/src/lib.rs
+++ b/end_to_end_tests/src/lib.rs
@@ -89,7 +89,7 @@ impl Setup {
                     if let Some(err) = &status.err {
                         panic!("Transaction failed with error {:?}", err);
                     }
-                    if status.satisfies_commitment(CommitmentConfig::finalized()) {
+                    if status.satisfies_commitment(CommitmentConfig::confirmed()) {
                         return;
                     }
                 }

--- a/end_to_end_tests/tests/end_to_end.rs
+++ b/end_to_end_tests/tests/end_to_end.rs
@@ -27,7 +27,7 @@ const PUBKEY_B: &str = "G7Ut56qgcEphHZmLhLimM2DfHVC7QwHfT18tvj8ntn9";
 // `NONCE_ACCOUNT_B` is an initialized nonce account with nonce authority `PUBKEY_B`
 const NONCE_ACCOUNT_B: &str = "876vg5npuF9LCfc2MVWZtewBUEfcgzdbahCK7gXn5MLh";
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "current_thread")]
 async fn should_send_transaction_with_recent_blockhash() {
     let sender_pubkey = Pubkey::from_str(ACCOUNT_A).unwrap();
     let sender_derivation_path = DerivationPath::from(DERIVATION_PATH_A);
@@ -71,7 +71,7 @@ async fn should_send_transaction_with_recent_blockhash() {
     .await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "current_thread")]
 async fn should_send_transaction_with_durable_nonce() {
     let sender_pubkey = Pubkey::from_str(PUBKEY_B).unwrap();
     let sender_derivation_path = DerivationPath::from(DERIVATION_PATH_B);

--- a/end_to_end_tests/tests/end_to_end.rs
+++ b/end_to_end_tests/tests/end_to_end.rs
@@ -8,22 +8,22 @@ use solana_compute_budget_interface::ComputeBudgetInstruction;
 use solana_hash::Hash;
 use solana_message::Message;
 use solana_program::system_instruction;
-use solana_pubkey::{pubkey, Pubkey};
+use solana_pubkey::Pubkey;
 use solana_transaction::Transaction;
 use std::str::FromStr;
 
 // Pubkey `ACCOUNT_A` was obtained with the `schnorr_public_key` with the team wallet canister ID
 // the derivation path `DERIVATION_PATH_A`, and the `test_key_1` key ID
 const DERIVATION_PATH_A: &[&[u8]] = &[&[1]];
-const ACCOUNT_A: &'static str = "2qL8z3PZS3tr8GV2x3z6mntNjNfLyh1VYcybfAENFSAn";
+const ACCOUNT_A: &str = "2qL8z3PZS3tr8GV2x3z6mntNjNfLyh1VYcybfAENFSAn";
 
 // Pubkey `PUBKEY_B` was obtained with the `schnorr_public_key` with the team wallet canister ID
 // the derivation path `DERIVATION_PATH_B`, and the `test_key_1` key ID
 const DERIVATION_PATH_B: &[&[u8]] = &[&[2]];
-const PUBKEY_B: &'static str = "rcvXBuRWbcXAPAWG6VgnjbehGPyLYqdfBHXL2L4XVCt";
+const PUBKEY_B: &str = "rcvXBuRWbcXAPAWG6VgnjbehGPyLYqdfBHXL2L4XVCt";
 
 // `NONCE_ACCOUNT_B` is an initialized nonce account with nonce authority `PUBKEY_B`
-const NONCE_ACCOUNT_B: &'static str = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+const NONCE_ACCOUNT_B: &str = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
 
 #[tokio::test(flavor = "multi_thread")]
 async fn should_send_transaction_with_recent_blockhash() {

--- a/end_to_end_tests/tests/end_to_end.rs
+++ b/end_to_end_tests/tests/end_to_end.rs
@@ -89,7 +89,7 @@ async fn should_send_transaction_with_durable_nonce() {
     let modify_instructions = |instructions: &mut Vec<Instruction>| {
         let advance_nonce_ix =
             system_instruction::advance_nonce_account(&sender_nonce_account, &sender_pubkey);
-        instructions.insert(2, advance_nonce_ix);
+        instructions.insert(0, advance_nonce_ix);
     };
 
     send_transaction_test(

--- a/end_to_end_tests/tests/end_to_end.rs
+++ b/end_to_end_tests/tests/end_to_end.rs
@@ -57,7 +57,7 @@ async fn should_send_transaction_with_recent_blockhash() {
     let modify_instructions = |instructions: &mut Vec<Instruction>| {
         // Set a CU limit for instructions to: perform a SOL transfer, set the CU price, and set the
         // CU limit
-        let set_cu_limit_ix = ComputeBudgetInstruction::set_compute_unit_limit(500);
+        let set_cu_limit_ix = ComputeBudgetInstruction::set_compute_unit_limit(450);
         instructions.insert(0, set_cu_limit_ix);
     };
 
@@ -94,8 +94,7 @@ async fn should_send_transaction_with_durable_nonce() {
     let modify_instructions = |instructions: &mut Vec<Instruction>| {
         // Set a CU limit for instructions to: perform a SOL transfer, advance the nonce account,
         // and set the CU price, and set the CU limit
-        // TODO XC-339: Revise estimate of CU limit
-        let set_cu_limit_ix = ComputeBudgetInstruction::set_compute_unit_limit(2000);
+        let set_cu_limit_ix = ComputeBudgetInstruction::set_compute_unit_limit(600);
         instructions.insert(0, set_cu_limit_ix);
         // Instruction to advance nonce account; this instruction must be first.
         let advance_nonce_ix =
@@ -183,7 +182,7 @@ async fn send_transaction_test<F, S>(
         .expect_consistent()
         .unwrap();
 
-    // Wait until the transaction is successfully executed and confirmed.
+    // Wait until the transaction is successfully executed and finalized.
     setup.confirm_transaction(&transaction_id).await;
 
     // Make sure the funds were sent from the sender to the recipient

--- a/end_to_end_tests/tests/end_to_end.rs
+++ b/end_to_end_tests/tests/end_to_end.rs
@@ -12,15 +12,18 @@ use solana_pubkey::{pubkey, Pubkey};
 use solana_transaction::Transaction;
 use std::str::FromStr;
 
-// Pubkey `PUBKEY_A` was obtained with the `schnorr_public_key` with the team wallet canister ID
+// Pubkey `ACCOUNT_A` was obtained with the `schnorr_public_key` with the team wallet canister ID
 // the derivation path `DERIVATION_PATH_A`, and the `test_key_1` key ID
 const DERIVATION_PATH_A: &[&[u8]] = &[&[1]];
-const PUBKEY_A: &'static str = "2qL8z3PZS3tr8GV2x3z6mntNjNfLyh1VYcybfAENFSAn";
+const ACCOUNT_A: &'static str = "2qL8z3PZS3tr8GV2x3z6mntNjNfLyh1VYcybfAENFSAn";
 
 // Pubkey `PUBKEY_B` was obtained with the `schnorr_public_key` with the team wallet canister ID
 // the derivation path `DERIVATION_PATH_B`, and the `test_key_1` key ID
 const DERIVATION_PATH_B: &[&[u8]] = &[&[2]];
 const PUBKEY_B: &'static str = "rcvXBuRWbcXAPAWG6VgnjbehGPyLYqdfBHXL2L4XVCt";
+
+// `NONCE_ACCOUNT_B` is an initialized nonce account with nonce authority `PUBKEY_B`
+const NONCE_ACCOUNT_B: &'static str = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
 
 #[tokio::test(flavor = "multi_thread")]
 async fn should_send_transaction_with_recent_blockhash() {
@@ -42,7 +45,7 @@ async fn should_send_transaction_with_recent_blockhash() {
         Hash::from_str(&block.blockhash).expect("Failed to parse blockhash")
     };
 
-    let sender_pubkey = Pubkey::from_str(PUBKEY_A).unwrap();
+    let sender_pubkey = Pubkey::from_str(ACCOUNT_A).unwrap();
     let sender_derivation_path = DerivationPath::from(DERIVATION_PATH_A);
     verify_pubkey(&sender_derivation_path, &sender_pubkey).await;
 
@@ -59,7 +62,7 @@ async fn should_send_transaction_with_recent_blockhash() {
 async fn should_send_transaction_with_durable_nonce() {
     let get_blockhash = async |client: &SolRpcClient<IcAgentRuntime>| {
         let account = client
-            .get_account_info(pubkey!(""))
+            .get_account_info(Pubkey::from_str(NONCE_ACCOUNT_B).unwrap())
             .send()
             .await
             .expect_consistent()
@@ -75,7 +78,7 @@ async fn should_send_transaction_with_durable_nonce() {
     send_transaction_test(
         sender_pubkey,
         sender_derivation_path,
-        Pubkey::from_str(PUBKEY_A).unwrap(),
+        Pubkey::from_str(ACCOUNT_A).unwrap(),
         get_blockhash,
     )
     .await;

--- a/end_to_end_tests/tests/end_to_end.rs
+++ b/end_to_end_tests/tests/end_to_end.rs
@@ -55,8 +55,8 @@ async fn should_send_transaction_with_recent_blockhash() {
     };
 
     let modify_instructions = |instructions: &mut Vec<Instruction>| {
-        // Set a CU limit for instructions to: perform a SOL transfer, set the CU price, and set the
-        // CU limit
+        // Set a CU limit for instructions to: perform a SOL transfer, set the CU price, and set
+        // the CU limit (150 CU x 3 = 450 CU)
         let set_cu_limit_ix = ComputeBudgetInstruction::set_compute_unit_limit(450);
         instructions.insert(0, set_cu_limit_ix);
     };
@@ -71,6 +71,7 @@ async fn should_send_transaction_with_recent_blockhash() {
     .await;
 }
 
+#[ignore]
 #[tokio::test(flavor = "multi_thread")]
 async fn should_send_transaction_with_durable_nonce() {
     let sender_pubkey = Pubkey::from_str(PUBKEY_B).unwrap();
@@ -93,7 +94,7 @@ async fn should_send_transaction_with_durable_nonce() {
 
     let modify_instructions = |instructions: &mut Vec<Instruction>| {
         // Set a CU limit for instructions to: perform a SOL transfer, advance the nonce account,
-        // and set the CU price, and set the CU limit
+        // and set the CU price, and set the CU limit (150 CU x 4 = 600 CU)
         let set_cu_limit_ix = ComputeBudgetInstruction::set_compute_unit_limit(600);
         instructions.insert(0, set_cu_limit_ix);
         // Instruction to advance nonce account; this instruction must be first.
@@ -148,7 +149,7 @@ async fn send_transaction_test<F, S>(
     let add_priority_fee_ix = ComputeBudgetInstruction::set_compute_unit_price(priority_fee);
 
     // Send some SOL from sender to recipient
-    let transaction_amount = 1_000;
+    let transaction_amount = 10_000;
     let transfer_ix =
         system_instruction::transfer(&sender_pubkey, &recipient_pubkey, transaction_amount);
 
@@ -182,7 +183,7 @@ async fn send_transaction_test<F, S>(
         .expect_consistent()
         .unwrap();
 
-    // Wait until the transaction is successfully executed and finalized.
+    // Wait until the transaction is successfully executed
     setup.confirm_transaction(&transaction_id).await;
 
     // Make sure the funds were sent from the sender to the recipient

--- a/end_to_end_tests/tests/end_to_end.rs
+++ b/end_to_end_tests/tests/end_to_end.rs
@@ -97,7 +97,7 @@ async fn should_send_transaction_with_durable_nonce() {
         // TODO XC-339: Revise estimate of CU limit
         let set_cu_limit_ix = ComputeBudgetInstruction::set_compute_unit_limit(2000);
         instructions.insert(0, set_cu_limit_ix);
-        // Instruction to advance nonce account
+        // Instruction to advance nonce account; this instruction must be first.
         let advance_nonce_ix =
             system_instruction::advance_nonce_account(&sender_nonce_account, &sender_pubkey);
         instructions.insert(0, advance_nonce_ix);

--- a/end_to_end_tests/tests/end_to_end.rs
+++ b/end_to_end_tests/tests/end_to_end.rs
@@ -46,7 +46,7 @@ const PUBKEY_B: Pubkey = pubkey!("G7Ut56qgcEphHZmLhLimM2DfHVC7QwHfT18tvj8ntn9");
 //  solana create-nonce-account nonce-keypair.json 0.01 --url devnet --nonce-authority $PUBKEY_B
 const NONCE_ACCOUNT_B: Pubkey = pubkey!("876vg5npuF9LCfc2MVWZtewBUEfcgzdbahCK7gXn5MLh");
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn should_send_transaction_with_recent_blockhash() {
     let setup = &Setup::new();
 
@@ -70,7 +70,7 @@ async fn should_send_transaction_with_recent_blockhash() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn should_send_transaction_with_durable_nonce() {
     let setup = &Setup::new();
 

--- a/end_to_end_tests/tests/end_to_end.rs
+++ b/end_to_end_tests/tests/end_to_end.rs
@@ -26,7 +26,7 @@ const DERIVATION_PATH_B: &[&[u8]] = &[&[2]];
 const PUBKEY_B: &str = "G7Ut56qgcEphHZmLhLimM2DfHVC7QwHfT18tvj8ntn9";
 
 // `NONCE_ACCOUNT_B` is an initialized nonce account with nonce authority `PUBKEY_B`
-const NONCE_ACCOUNT_B: &str = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+const NONCE_ACCOUNT_B: &str = "876vg5npuF9LCfc2MVWZtewBUEfcgzdbahCK7gXn5MLh";
 
 #[tokio::test(flavor = "multi_thread")]
 async fn should_send_transaction_with_recent_blockhash() {

--- a/end_to_end_tests/tests/end_to_end.rs
+++ b/end_to_end_tests/tests/end_to_end.rs
@@ -1,5 +1,9 @@
-use sol_rpc_client::ed25519::{get_pubkey, sign_message, Ed25519KeyId};
-use sol_rpc_e2e_tests::{env, Setup};
+use sol_rpc_client::{
+    ed25519::{get_pubkey, sign_message, DerivationPath, Ed25519KeyId},
+    nonce::extract_durable_nonce,
+    SolRpcClient,
+};
+use sol_rpc_e2e_tests::{IcAgentRuntime, Setup};
 use solana_compute_budget_interface::ComputeBudgetInstruction;
 use solana_hash::Hash;
 use solana_message::Message;
@@ -8,28 +12,83 @@ use solana_pubkey::{pubkey, Pubkey};
 use solana_transaction::Transaction;
 use std::str::FromStr;
 
+// Pubkey `PUBKEY_A` was obtained with the `schnorr_public_key` with the team wallet canister ID
+// the derivation path `DERIVATION_PATH_A`, and the `test_key_1` key ID
+const DERIVATION_PATH_A: &[&[u8]] = &[&[1]];
+const PUBKEY_A: &'static str = "2qL8z3PZS3tr8GV2x3z6mntNjNfLyh1VYcybfAENFSAn";
+
+// Pubkey `PUBKEY_B` was obtained with the `schnorr_public_key` with the team wallet canister ID
+// the derivation path `DERIVATION_PATH_B`, and the `test_key_1` key ID
+const DERIVATION_PATH_B: &[&[u8]] = &[&[2]];
+const PUBKEY_B: &'static str = "rcvXBuRWbcXAPAWG6VgnjbehGPyLYqdfBHXL2L4XVCt";
+
 #[tokio::test(flavor = "multi_thread")]
 async fn should_send_transaction_with_recent_blockhash() {
+    let get_blockhash = async |client: &SolRpcClient<IcAgentRuntime>| {
+        // TODO XC-317: Use method to estimate recent blockhash
+        let slot = client
+            .get_slot()
+            .send()
+            .await
+            .expect_consistent()
+            .expect("Call to get slot failed");
+        let block = client
+            .get_block(slot)
+            .send()
+            .await
+            .expect_consistent()
+            .expect("Call to `getBlock` failed")
+            .expect("Block not found");
+        Hash::from_str(&block.blockhash).expect("Failed to parse blockhash")
+    };
+
+    let sender_pubkey = Pubkey::from_str(PUBKEY_A).unwrap();
+    let sender_derivation_path = DerivationPath::from(DERIVATION_PATH_A);
+    verify_pubkey(&sender_derivation_path, &sender_pubkey).await;
+
+    send_transaction_test(
+        sender_pubkey,
+        sender_derivation_path,
+        Pubkey::from_str(PUBKEY_B).unwrap(),
+        get_blockhash,
+    )
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn should_send_transaction_with_durable_nonce() {
+    let get_blockhash = async |client: &SolRpcClient<IcAgentRuntime>| {
+        let account = client
+            .get_account_info(pubkey!(""))
+            .send()
+            .await
+            .expect_consistent()
+            .expect("Call to `getAccountInfo` failed")
+            .expect("Account not found");
+        extract_durable_nonce(&account).expect("Failed to extract durable nonce from account")
+    };
+
+    let sender_pubkey = Pubkey::from_str(PUBKEY_B).unwrap();
+    let sender_derivation_path = DerivationPath::from(DERIVATION_PATH_B);
+    verify_pubkey(&sender_derivation_path, &sender_pubkey).await;
+
+    send_transaction_test(
+        sender_pubkey,
+        sender_derivation_path,
+        Pubkey::from_str(PUBKEY_A).unwrap(),
+        get_blockhash,
+    )
+    .await;
+}
+
+async fn send_transaction_test<F: AsyncFnOnce(&SolRpcClient<IcAgentRuntime>) -> Hash>(
+    sender_pubkey: Pubkey,
+    sender_derivation_path: DerivationPath,
+    recipient_pubkey: Pubkey,
+    get_blockhash: F,
+) {
     let setup = Setup::new();
     let client = setup.client();
-
-    // Get the pubkey of the sender, which is derived from the given root Ed25519 key, and the
-    // canister ID of the wallet canister (through which all calls are forwarded).
-    let (sender_pubkey, _) =
-        get_pubkey(client.runtime(), None, None, Ed25519KeyId::MainnetTestKey1)
-            .await
-            .unwrap_or_else(|e| panic!("Failed to get Ed25519 public key: {e:?}"));
-    assert_eq!(
-        sender_pubkey,
-        pubkey!("2qL8z3PZS3tr8GV2x3z6mntNjNfLyh1VYcybfAENFSAn")
-    );
-
-    fn load_pubkey(key: &str) -> Pubkey {
-        Pubkey::from_str(&env(key)).unwrap_or_else(|e| {
-            panic!("Failed to parse environment variable '{key}' as a valid pubkey: {e}")
-        })
-    }
-    let recipient_pubkey = load_pubkey("SOLANA_RECEIVER_PUBLIC_KEY");
 
     let sender_balance_before = setup.fund_account(&sender_pubkey, 1_000_000_000).await;
     let recipient_balance_before = setup.fund_account(&recipient_pubkey, 1_000_000_000).await;
@@ -61,21 +120,7 @@ async fn should_send_transaction_with_recent_blockhash() {
     let transfer_ix =
         system_instruction::transfer(&sender_pubkey, &recipient_pubkey, transaction_amount);
 
-    // TODO XC-317: Use method to estimate recent blockhash
-    let slot = client
-        .get_slot()
-        .send()
-        .await
-        .expect_consistent()
-        .expect("Call to get slot failed");
-    let block = client
-        .get_block(slot)
-        .send()
-        .await
-        .expect_consistent()
-        .expect("Call to `getBlock` failed")
-        .expect("Block not found");
-    let blockhash = Hash::from_str(&block.blockhash).expect("Failed to parse blockhash");
+    let blockhash = get_blockhash(&client).await;
 
     let message = Message::new_with_blockhash(
         &[set_cu_limit_ix, add_priority_fee_ix, transfer_ix],
@@ -88,7 +133,7 @@ async fn should_send_transaction_with_recent_blockhash() {
         client.runtime(),
         &message,
         Ed25519KeyId::MainnetTestKey1,
-        None,
+        Some(&sender_derivation_path),
     )
     .await
     .expect("Failed to sign transaction");
@@ -119,7 +164,14 @@ async fn should_send_transaction_with_recent_blockhash() {
     assert!(sender_balance_after + transaction_amount <= sender_balance_before);
 }
 
-#[tokio::test(flavor = "multi_thread")]
-async fn should_send_transaction_with_durable_nonce() {
-    // TODO XC-347: Same as `should_send_transaction_with_recent_blockhash` but with a durable nonce
+async fn verify_pubkey(derivation_path: &DerivationPath, expected_pubkey: &Pubkey) {
+    let (pubkey, _) = get_pubkey(
+        Setup::new().client().runtime(),
+        None,
+        Some(derivation_path),
+        Ed25519KeyId::MainnetTestKey1,
+    )
+    .await
+    .unwrap_or_else(|e| panic!("Failed to get Ed25519 public key: {e:?}"));
+    assert_eq!(&pubkey, expected_pubkey);
 }

--- a/end_to_end_tests/tests/end_to_end.rs
+++ b/end_to_end_tests/tests/end_to_end.rs
@@ -1,6 +1,6 @@
 use sol_rpc_client::{
     ed25519::{get_pubkey, sign_message, DerivationPath, Ed25519KeyId},
-    nonce::extract_durable_nonce,
+    nonce::nonce_from_account,
     SolRpcClient,
 };
 use sol_rpc_e2e_tests::{IcAgentRuntime, Setup};
@@ -88,7 +88,7 @@ async fn should_send_transaction_with_durable_nonce() {
             .expect_consistent()
             .expect("Call to `getAccountInfo` failed")
             .expect("Account not found");
-        extract_durable_nonce(&account).expect("Failed to extract durable nonce from account")
+        nonce_from_account(&account).expect("Failed to extract durable nonce from account")
     };
 
     let modify_instructions = |instructions: &mut Vec<Instruction>| {

--- a/end_to_end_tests/tests/end_to_end.rs
+++ b/end_to_end_tests/tests/end_to_end.rs
@@ -27,7 +27,7 @@ const PUBKEY_B: &str = "G7Ut56qgcEphHZmLhLimM2DfHVC7QwHfT18tvj8ntn9";
 // `NONCE_ACCOUNT_B` is an initialized nonce account with nonce authority `PUBKEY_B`
 const NONCE_ACCOUNT_B: &str = "876vg5npuF9LCfc2MVWZtewBUEfcgzdbahCK7gXn5MLh";
 
-#[tokio::test(flavor = "current_thread")]
+#[tokio::test]
 async fn should_send_transaction_with_recent_blockhash() {
     let sender_pubkey = Pubkey::from_str(ACCOUNT_A).unwrap();
     let sender_derivation_path = DerivationPath::from(DERIVATION_PATH_A);
@@ -71,7 +71,7 @@ async fn should_send_transaction_with_recent_blockhash() {
     .await;
 }
 
-#[tokio::test(flavor = "current_thread")]
+#[tokio::test]
 async fn should_send_transaction_with_durable_nonce() {
     let sender_pubkey = Pubkey::from_str(PUBKEY_B).unwrap();
     let sender_derivation_path = DerivationPath::from(DERIVATION_PATH_B);
@@ -199,12 +199,6 @@ async fn send_transaction_test<F, S>(
         status.slot
     );
 
-    // Extract the fees from the block in which the transaction is included
-    let transaction_fees = setup
-        .get_transaction_fee(&transaction_id, status.slot)
-        .await;
-    println!("Transaction fees for sender: {transaction_fees:?}");
-
     // Make sure the funds were sent from the sender to the recipient
     let sender_balance_after = setup.get_account_balance(&sender_pubkey).await;
     println!("Sender balance after sending transaction: {sender_balance_before:?} lamports");
@@ -215,10 +209,7 @@ async fn send_transaction_test<F, S>(
         recipient_balance_after,
         recipient_balance_before + transaction_amount
     );
-    assert_eq!(
-        sender_balance_after,
-        sender_balance_before - transaction_amount - transaction_fees,
-    );
+    assert!(sender_balance_after <= sender_balance_before - transaction_amount);
 }
 
 async fn verify_pubkey(derivation_path: &DerivationPath, expected_pubkey: &Pubkey) {

--- a/end_to_end_tests/tests/end_to_end.rs
+++ b/end_to_end_tests/tests/end_to_end.rs
@@ -28,6 +28,7 @@ const PUBKEY_B: &str = "G7Ut56qgcEphHZmLhLimM2DfHVC7QwHfT18tvj8ntn9";
 // `NONCE_ACCOUNT_B` is an initialized nonce account with nonce authority `PUBKEY_B`
 const NONCE_ACCOUNT_B: &str = "876vg5npuF9LCfc2MVWZtewBUEfcgzdbahCK7gXn5MLh";
 
+#[ignore]
 #[tokio::test(flavor = "multi_thread")]
 async fn should_send_transaction_with_recent_blockhash() {
     let sender_pubkey = Pubkey::from_str(ACCOUNT_A).unwrap();
@@ -71,7 +72,6 @@ async fn should_send_transaction_with_recent_blockhash() {
     .await;
 }
 
-#[ignore]
 #[tokio::test(flavor = "multi_thread")]
 async fn should_send_transaction_with_durable_nonce() {
     let sender_pubkey = Pubkey::from_str(PUBKEY_B).unwrap();

--- a/examples/basic_solana/src/lib.rs
+++ b/examples/basic_solana/src/lib.rs
@@ -6,9 +6,7 @@ pub mod state;
 use crate::state::{read_state, State};
 use candid::{CandidType, Deserialize, Principal};
 use sol_rpc_client::{ed25519::Ed25519KeyId, IcRuntime, SolRpcClient};
-use sol_rpc_types::{
-    CommitmentLevel, ConsensusStrategy, MultiRpcResult, RpcConfig, RpcSources, SolanaCluster,
-};
+use sol_rpc_types::{CommitmentLevel, MultiRpcResult, RpcSources, SolanaCluster};
 use solana_hash::Hash;
 use std::str::FromStr;
 

--- a/examples/basic_solana/src/lib.rs
+++ b/examples/basic_solana/src/lib.rs
@@ -6,7 +6,9 @@ pub mod state;
 use crate::state::{read_state, State};
 use candid::{CandidType, Deserialize, Principal};
 use sol_rpc_client::{ed25519::Ed25519KeyId, IcRuntime, SolRpcClient};
-use sol_rpc_types::{CommitmentLevel, MultiRpcResult, RpcSources, SolanaCluster};
+use sol_rpc_types::{
+    CommitmentLevel, ConsensusStrategy, MultiRpcResult, RpcConfig, RpcSources, SolanaCluster,
+};
 use solana_hash::Hash;
 use std::str::FromStr;
 


### PR DESCRIPTION
(XC-339) Add an end-to-end test for `sendTransaction` using a durable nonce instead of a recent blockhash to construct the Solana transaction.