### PR TITLE
chore: use 2-out-of-3 threshold consensus for `basic_solana`

### DIFF
--- a/examples/basic_solana/src/lib.rs
+++ b/examples/basic_solana/src/lib.rs
@@ -6,7 +6,9 @@ pub mod state;
 use crate::state::{read_state, State};
 use candid::{CandidType, Deserialize, Principal};
 use sol_rpc_client::{ed25519::Ed25519KeyId, IcRuntime, SolRpcClient};
-use sol_rpc_types::{CommitmentLevel, MultiRpcResult, RpcSources, SolanaCluster};
+use sol_rpc_types::{
+    CommitmentLevel, ConsensusStrategy, MultiRpcResult, RpcConfig, RpcSources, SolanaCluster,
+};
 use solana_hash::Hash;
 use std::str::FromStr;
 
@@ -60,6 +62,13 @@ pub fn client() -> SolRpcClient<IcRuntime> {
         .with_rpc_sources(RpcSources::Default(
             read_state(|state| state.solana_network()).into(),
         ))
+        .with_rpc_config(RpcConfig {
+            response_consensus: Some(ConsensusStrategy::Threshold {
+                min: 2,
+                total: Some(3),
+            }),
+            ..RpcConfig::default()
+        })
         .with_default_commitment_level(read_state(State::solana_commitment_level))
         .build()
 }


### PR DESCRIPTION
Use a 2-out of-3 threshold consensus strategy for the `basic_solana` example instead of equality to increase robustness in case one of issues with one of the providers.