### PR TITLE
chore: add client builder method to set consensus strategy

### DIFF
--- a/end_to_end_tests/src/lib.rs
+++ b/end_to_end_tests/src/lib.rs
@@ -60,12 +60,9 @@ impl Setup {
                 RpcSource::Supported(SupportedRpcProviderId::DrpcDevnet),
                 RpcSource::Supported(SupportedRpcProviderId::HeliusDevnet),
             ]))
-            .with_rpc_config(RpcConfig {
-                response_consensus: Some(ConsensusStrategy::Threshold {
-                    min: 2,
-                    total: None,
-                }),
-                ..RpcConfig::default()
+            .with_consensus_strategy(ConsensusStrategy::Threshold {
+                min: 2,
+                total: None,
             })
             .with_default_commitment_level(CommitmentLevel::Confirmed)
             .build()

--- a/examples/basic_solana/src/lib.rs
+++ b/examples/basic_solana/src/lib.rs
@@ -62,12 +62,9 @@ pub fn client() -> SolRpcClient<IcRuntime> {
         .with_rpc_sources(RpcSources::Default(
             read_state(|state| state.solana_network()).into(),
         ))
-        .with_rpc_config(RpcConfig {
-            response_consensus: Some(ConsensusStrategy::Threshold {
-                min: 2,
-                total: Some(3),
-            }),
-            ..RpcConfig::default()
+        .with_consensus_strategy(ConsensusStrategy::Threshold {
+            min: 2,
+            total: Some(3),
         })
         .with_default_commitment_level(read_state(State::solana_commitment_level))
         .build()

--- a/examples/basic_solana/src/lib.rs
+++ b/examples/basic_solana/src/lib.rs
@@ -6,7 +6,9 @@ pub mod state;
 use crate::state::{read_state, State};
 use candid::{CandidType, Deserialize, Principal};
 use sol_rpc_client::{ed25519::Ed25519KeyId, IcRuntime, SolRpcClient};
-use sol_rpc_types::{CommitmentLevel, MultiRpcResult, RpcSources, SolanaCluster};
+use sol_rpc_types::{
+    CommitmentLevel, ConsensusStrategy, MultiRpcResult, RpcConfig, RpcSources, SolanaCluster,
+};
 use solana_hash::Hash;
 use std::str::FromStr;
 
@@ -60,6 +62,13 @@ pub fn client() -> SolRpcClient<IcRuntime> {
         .with_rpc_sources(RpcSources::Default(
             read_state(|state| state.solana_network()).into(),
         ))
+        .with_rpc_config(RpcConfig {
+            response_consensus: Some(ConsensusStrategy::Threshold {
+                min: 2,
+                total: Some(3),
+            }),
+            ..RpcConfig::default()
+        })
         .with_default_commitment_level(read_state(State::solana_commitment_level))
         .build()
 }

--- a/libs/client/src/lib.rs
+++ b/libs/client/src/lib.rs
@@ -138,7 +138,7 @@ use ic_cdk::api::call::RejectionCode;
 pub use request::{Request, RequestBuilder, SolRpcEndpoint, SolRpcRequest};
 use serde::de::DeserializeOwned;
 use sol_rpc_types::{
-    CommitmentLevel, GetAccountInfoParams, GetBalanceParams, GetBlockParams,
+    CommitmentLevel, ConsensusStrategy, GetAccountInfoParams, GetBalanceParams, GetBlockParams,
     GetRecentPrioritizationFeesParams, GetSignatureStatusesParams, GetSignaturesForAddressParams,
     GetSlotParams, GetSlotRpcConfig, GetTokenAccountBalanceParams, GetTransactionParams, Lamport,
     Pubkey, RpcConfig, RpcResult, RpcSources, SendTransactionParams, Signature, Slot,
@@ -275,6 +275,15 @@ impl<R> ClientBuilder<R> {
     /// Mutates the builder to use the given [`RpcConfig`].
     pub fn with_rpc_config(mut self, rpc_config: RpcConfig) -> Self {
         self.config.rpc_config = Some(rpc_config);
+        self
+    }
+
+    /// Mutates the builder to use the given [`ConsensusStrategy`] in the [`RpcConfig`].
+    pub fn with_consensus_strategy(mut self, consensus_strategy: ConsensusStrategy) -> Self {
+        self.config.rpc_config = Some(RpcConfig {
+            response_consensus: Some(consensus_strategy),
+            ..self.config.rpc_config.unwrap_or_default()
+        });
         self
     }
 


### PR DESCRIPTION
Add a new `with_consensus_strategy` method to `ClientBuilder`.