### PR TITLE
chore: add helper methods for request builders

### DIFF
--- a/canister/src/rpc_client/tests.rs
+++ b/canister/src/rpc_client/tests.rs
@@ -7,10 +7,12 @@ use serde::Serialize;
 use serde_json::json;
 use sol_rpc_types::{
     CommitmentLevel, DataSlice, GetAccountInfoEncoding, GetAccountInfoParams, GetBalanceParams,
-    GetBlockCommitmentLevel, GetBlockParams, GetSignatureStatusesParams,
+    GetBlockCommitmentLevel, GetBlockParams, GetRecentPrioritizationFeesParams,
+    GetRecentPrioritizationFeesRpcConfig, GetSignatureStatusesParams,
     GetSignaturesForAddressParams, GetSlotParams, GetSlotRpcConfig, GetTokenAccountBalanceParams,
     GetTransactionEncoding, GetTransactionParams, Pubkey, RpcConfig, RpcSources,
     SendTransactionEncoding, SendTransactionParams, Signature, SolanaCluster, TransactionDetails,
+    VecWithMaxLen,
 };
 use solana_pubkey::pubkey;
 use std::str::FromStr;
@@ -22,7 +24,6 @@ const ANOTHER_SIGNATURE: &str =
 
 mod request_serialization_tests {
     use super::*;
-    use sol_rpc_types::{GetRecentPrioritizationFeesParams, GetRecentPrioritizationFeesRpcConfig};
 
     #[test]
     fn should_serialize_get_account_info_request() {
@@ -144,7 +145,7 @@ mod request_serialization_tests {
                 RpcSources::Default(SolanaCluster::Mainnet),
                 RpcConfig::default(),
                 GetSignatureStatusesParams {
-                    signatures: vec![].try_into().unwrap(),
+                    signatures: VecWithMaxLen::new(),
                     search_transaction_history: None,
                 },
             )

--- a/integration_tests/tests/tests.rs
+++ b/integration_tests/tests/tests.rs
@@ -1782,10 +1782,8 @@ mod get_balance_tests {
                 ])
                 .build()
                 .get_balance(USDC_PUBLIC_KEY)
-                .modify_params(|params| {
-                    params.commitment = Some(CommitmentLevel::Confirmed);
-                    params.min_context_slot = Some(100);
-                })
+                .with_min_context_slot(100)
+                .with_commitment(CommitmentLevel::Confirmed)
                 .send()
                 .await
                 .expect_consistent();
@@ -1848,9 +1846,7 @@ mod get_token_account_balance_tests {
                 ])
                 .build()
                 .get_token_account_balance(USDC_PUBLIC_KEY)
-                .modify_params(|params| {
-                    params.commitment = Some(CommitmentLevel::Confirmed);
-                })
+                .with_commitment(CommitmentLevel::Confirmed)
                 .send()
                 .await
                 .expect_consistent();

--- a/libs/client/Cargo.toml
+++ b/libs/client/Cargo.toml
@@ -46,4 +46,6 @@ ed25519 = [
 
 [dev-dependencies]
 assert_matches = { workspace = true }
+solana-keypair = { workspace = true }
+solana-transaction = { workspace = true }
 tokio = { workspace = true, features = ["full"] }

--- a/libs/client/src/lib.rs
+++ b/libs/client/src/lib.rs
@@ -143,13 +143,10 @@ use serde::de::DeserializeOwned;
 use sol_rpc_types::{
     CommitmentLevel, ConsensusStrategy, GetAccountInfoParams, GetBalanceParams, GetBlockParams,
     GetRecentPrioritizationFeesParams, GetSignatureStatusesParams, GetSignaturesForAddressParams,
-    GetSlotParams, GetSlotRpcConfig, GetTokenAccountBalanceParams, GetTransactionParams, Lamport,
-    Pubkey, RpcConfig, RpcResult, RpcSources, SendTransactionParams, Signature, Slot,
-    SolanaCluster, SupportedRpcProvider, SupportedRpcProviderId, TokenAmount, TransactionDetails,
-    TransactionInfo,
+    GetTokenAccountBalanceParams, GetTransactionParams, Pubkey, RpcConfig, RpcResult, RpcSources,
+    SendTransactionParams, SolanaCluster, SupportedRpcProvider, SupportedRpcProviderId,
+    TransactionDetails,
 };
-use solana_account_decoder_client_types::token::UiTokenAmount;
-use solana_transaction_status_client_types::EncodedConfirmedTransactionWithStatusMeta;
 use std::{fmt::Debug, sync::Arc};
 /// The principal identifying the productive Solana RPC canister under NNS control.
 ///

--- a/libs/client/src/lib.rs
+++ b/libs/client/src/lib.rs
@@ -126,11 +126,14 @@ pub mod nonce;
 mod request;
 
 use crate::request::{
-    GetAccountInfoRequest, GetAccountInfoRequestBuilder, GetBalanceRequest, GetBlockRequest,
+    GetAccountInfoRequest, GetAccountInfoRequestBuilder, GetBalanceRequest,
+    GetBalanceRequestBuilder, GetBlockRequest, GetBlockRequestBuilder,
     GetRecentPrioritizationFeesRequest, GetRecentPrioritizationFeesRequestBuilder,
     GetSignatureStatusesRequest, GetSignatureStatusesRequestBuilder,
     GetSignaturesForAddressRequest, GetSignaturesForAddressRequestBuilder, GetSlotRequest,
-    GetTokenAccountBalanceRequest, GetTransactionRequest, JsonRequest, SendTransactionRequest,
+    GetSlotRequestBuilder, GetTokenAccountBalanceRequest, GetTokenAccountBalanceRequestBuilder,
+    GetTransactionRequest, GetTransactionRequestBuilder, JsonRequest, JsonRequestBuilder,
+    SendTransactionRequest, SendTransactionRequestBuilder,
 };
 use async_trait::async_trait;
 use candid::{utils::ArgumentEncoder, CandidType, Principal};
@@ -381,16 +384,7 @@ impl<R> SolRpcClient<R> {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn get_balance(
-        &self,
-        params: impl Into<GetBalanceParams>,
-    ) -> RequestBuilder<
-        R,
-        RpcConfig,
-        GetBalanceParams,
-        sol_rpc_types::MultiRpcResult<Lamport>,
-        sol_rpc_types::MultiRpcResult<Lamport>,
-    > {
+    pub fn get_balance(&self, params: impl Into<GetBalanceParams>) -> GetBalanceRequestBuilder<R> {
         RequestBuilder::new(
             self.clone(),
             GetBalanceRequest::new(params.into()),
@@ -399,18 +393,7 @@ impl<R> SolRpcClient<R> {
     }
 
     /// Call `getBlock` on the SOL RPC canister.
-    pub fn get_block(
-        &self,
-        params: impl Into<GetBlockParams>,
-    ) -> RequestBuilder<
-        R,
-        RpcConfig,
-        GetBlockParams,
-        sol_rpc_types::MultiRpcResult<Option<sol_rpc_types::ConfirmedBlock>>,
-        sol_rpc_types::MultiRpcResult<
-            Option<solana_transaction_status_client_types::UiConfirmedBlock>,
-        >,
-    > {
+    pub fn get_block(&self, params: impl Into<GetBlockParams>) -> GetBlockRequestBuilder<R> {
         let params = params.into();
         let cycles = match params.transaction_details.unwrap_or_default() {
             TransactionDetails::Signatures => 100_000_000_000,
@@ -460,13 +443,7 @@ impl<R> SolRpcClient<R> {
     pub fn get_token_account_balance(
         &self,
         params: impl Into<GetTokenAccountBalanceParams>,
-    ) -> RequestBuilder<
-        R,
-        RpcConfig,
-        GetTokenAccountBalanceParams,
-        sol_rpc_types::MultiRpcResult<TokenAmount>,
-        sol_rpc_types::MultiRpcResult<UiTokenAmount>,
-    > {
+    ) -> GetTokenAccountBalanceRequestBuilder<R> {
         RequestBuilder::new(
             self.clone(),
             GetTokenAccountBalanceRequest::new(params.into()),
@@ -770,15 +747,7 @@ impl<R> SolRpcClient<R> {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn get_slot(
-        &self,
-    ) -> RequestBuilder<
-        R,
-        GetSlotRpcConfig,
-        Option<GetSlotParams>,
-        sol_rpc_types::MultiRpcResult<Slot>,
-        sol_rpc_types::MultiRpcResult<Slot>,
-    > {
+    pub fn get_slot(&self) -> GetSlotRequestBuilder<R> {
         RequestBuilder::new(self.clone(), GetSlotRequest::default(), 10_000_000_000)
     }
 
@@ -786,13 +755,7 @@ impl<R> SolRpcClient<R> {
     pub fn get_transaction(
         &self,
         params: impl Into<GetTransactionParams>,
-    ) -> RequestBuilder<
-        R,
-        RpcConfig,
-        GetTransactionParams,
-        sol_rpc_types::MultiRpcResult<Option<TransactionInfo>>,
-        sol_rpc_types::MultiRpcResult<Option<EncodedConfirmedTransactionWithStatusMeta>>,
-    > {
+    ) -> GetTransactionRequestBuilder<R> {
         RequestBuilder::new(
             self.clone(),
             GetTransactionRequest::new(params.into()),
@@ -834,16 +797,7 @@ impl<R> SolRpcClient<R> {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn send_transaction<T>(
-        &self,
-        params: T,
-    ) -> RequestBuilder<
-        R,
-        RpcConfig,
-        SendTransactionParams,
-        sol_rpc_types::MultiRpcResult<Signature>,
-        sol_rpc_types::MultiRpcResult<solana_signature::Signature>,
-    >
+    pub fn send_transaction<T>(&self, params: T) -> SendTransactionRequestBuilder<R>
     where
         T: TryInto<SendTransactionParams>,
         <T as TryInto<SendTransactionParams>>::Error: Debug,
@@ -913,16 +867,7 @@ impl<R> SolRpcClient<R> {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn json_request(
-        &self,
-        json_request: serde_json::Value,
-    ) -> RequestBuilder<
-        R,
-        RpcConfig,
-        String,
-        sol_rpc_types::MultiRpcResult<String>,
-        sol_rpc_types::MultiRpcResult<String>,
-    > {
+    pub fn json_request(&self, json_request: serde_json::Value) -> JsonRequestBuilder<R> {
         RequestBuilder::new(
             self.clone(),
             JsonRequest::try_from(json_request).expect("Client error: invalid JSON request"),

--- a/libs/client/src/request/mod.rs
+++ b/libs/client/src/request/mod.rs
@@ -442,17 +442,13 @@ pub type GetSlotRequestBuilder<R> = RequestBuilder<
 impl<R> GetSlotRequestBuilder<R> {
     /// Change the `commitment` parameter for a `getSlot` request.
     pub fn with_commitment(mut self, commitment_level: CommitmentLevel) -> Self {
-        let mut config = self.request.params.unwrap_or_default();
-        config.commitment = Some(commitment_level);
-        self.request.params = Some(config);
+        self.request.params.get_or_insert_default().commitment = Some(commitment_level);
         self
     }
 
     /// Change the `minContextSlot` parameter for a `getSlot` request.
     pub fn with_min_context_slot(mut self, slot: Slot) -> Self {
-        let mut config = self.request.params.unwrap_or_default();
-        config.min_context_slot = Some(slot);
-        self.request.params = Some(config);
+        self.request.params.get_or_insert_default().min_context_slot = Some(slot);
         self
     }
 }

--- a/libs/client/src/request/mod.rs
+++ b/libs/client/src/request/mod.rs
@@ -7,13 +7,13 @@ use derive_more::From;
 use serde::de::DeserializeOwned;
 use sol_rpc_types::{
     AccountInfo, CommitmentLevel, ConfirmedBlock, ConfirmedTransactionStatusWithSignature,
-    GetAccountInfoEncoding, GetAccountInfoParams, GetBalanceParams, GetBlockCommitmentLevel,
-    GetBlockParams, GetRecentPrioritizationFeesParams, GetRecentPrioritizationFeesRpcConfig,
-    GetSignatureStatusesParams, GetSignaturesForAddressLimit, GetSignaturesForAddressParams,
-    GetSlotParams, GetSlotRpcConfig, GetTokenAccountBalanceParams, GetTransactionEncoding,
-    GetTransactionParams, Lamport, MultiRpcResult, NonZeroU8, PrioritizationFee, RoundingError,
-    RpcConfig, RpcResult, RpcSources, SendTransactionParams, Signature, Slot, TokenAmount,
-    TransactionDetails, TransactionInfo, TransactionStatus,
+    DataSlice, GetAccountInfoEncoding, GetAccountInfoParams, GetBalanceParams,
+    GetBlockCommitmentLevel, GetBlockParams, GetRecentPrioritizationFeesParams,
+    GetRecentPrioritizationFeesRpcConfig, GetSignatureStatusesParams, GetSignaturesForAddressLimit,
+    GetSignaturesForAddressParams, GetSlotParams, GetSlotRpcConfig, GetTokenAccountBalanceParams,
+    GetTransactionEncoding, GetTransactionParams, Lamport, MultiRpcResult, NonZeroU8,
+    PrioritizationFee, RoundingError, RpcConfig, RpcResult, RpcSources, SendTransactionParams,
+    Signature, Slot, TokenAmount, TransactionDetails, TransactionInfo, TransactionStatus,
 };
 use solana_account_decoder_client_types::token::UiTokenAmount;
 use solana_transaction_status_client_types::{
@@ -138,9 +138,27 @@ pub type GetAccountInfoRequestBuilder<R> = RequestBuilder<
 >;
 
 impl<R> GetAccountInfoRequestBuilder<R> {
+    /// Change the `commitment` parameter for a `getAccountInfo` request.
+    pub fn with_commitment(mut self, commitment: impl Into<CommitmentLevel>) -> Self {
+        self.request.params.commitment = Some(commitment.into());
+        self
+    }
+
     /// Change the `encoding` parameter for a `getAccountInfo` request.
-    pub fn with_encoding(mut self, encoding: GetAccountInfoEncoding) -> Self {
-        self.request.params.encoding = Some(encoding);
+    pub fn with_encoding(mut self, encoding: impl Into<GetAccountInfoEncoding>) -> Self {
+        self.request.params.encoding = Some(encoding.into());
+        self
+    }
+
+    /// Change the `dataSlice` parameter for a `getAccountInfo` request.
+    pub fn with_data_slice(mut self, data_slice: impl Into<DataSlice>) -> Self {
+        self.request.params.data_slice = Some(data_slice.into());
+        self
+    }
+
+    /// Change the `minContextSlot` parameter for a `getAccountInfo` request.
+    pub fn with_min_context_slot(mut self, slot: Slot) -> Self {
+        self.request.params.min_context_slot = Some(slot);
         self
     }
 }
@@ -181,8 +199,8 @@ pub type GetBalanceRequestBuilder<R> = RequestBuilder<
 
 impl<R> GetBalanceRequestBuilder<R> {
     /// Change the `commitment` parameter for a `getBalance` request.
-    pub fn with_commitment(mut self, commitment_level: CommitmentLevel) -> Self {
-        self.request.params.commitment = Some(commitment_level);
+    pub fn with_commitment(mut self, commitment_level: impl Into<CommitmentLevel>) -> Self {
+        self.request.params.commitment = Some(commitment_level.into());
         self
     }
 
@@ -242,8 +260,8 @@ pub type GetBlockRequestBuilder<R> = RequestBuilder<
 
 impl<R> GetBlockRequestBuilder<R> {
     /// Change the `commitment` parameter for a `getBlock` request.
-    pub fn with_commitment(mut self, commitment_level: GetBlockCommitmentLevel) -> Self {
-        self.request.params.commitment = Some(commitment_level);
+    pub fn with_commitment(mut self, commitment_level: impl Into<GetBlockCommitmentLevel>) -> Self {
+        self.request.params.commitment = Some(commitment_level.into());
         self
     }
 
@@ -254,8 +272,11 @@ impl<R> GetBlockRequestBuilder<R> {
     }
 
     /// Change the `transactionDetails` parameter for a `getBlock` request.
-    pub fn with_transaction_details(mut self, transaction_details: TransactionDetails) -> Self {
-        self.request.params.transaction_details = Some(transaction_details);
+    pub fn with_transaction_details(
+        mut self,
+        transaction_details: impl Into<TransactionDetails>,
+    ) -> Self {
+        self.request.params.transaction_details = Some(transaction_details.into());
         self
     }
 }
@@ -318,6 +339,12 @@ impl<R> GetSignaturesForAddressRequestBuilder<R> {
     /// Change the `commitment` parameter for a `getSignaturesForAddress` request.
     pub fn with_commitment(mut self, commitment_level: CommitmentLevel) -> Self {
         self.request.params.commitment = Some(commitment_level);
+        self
+    }
+
+    /// Change the `minContextSlot` parameter for a `getSignaturesForAddress` request.
+    pub fn with_min_context_slot(mut self, slot: Slot) -> Self {
+        self.request.params.min_context_slot = Some(slot);
         self
     }
 
@@ -559,6 +586,32 @@ pub type SendTransactionRequestBuilder<R> = RequestBuilder<
     MultiRpcResult<Signature>,
     MultiRpcResult<solana_signature::Signature>,
 >;
+
+impl<R> SendTransactionRequestBuilder<R> {
+    /// Change the `skipPreflight` parameter for a `sendTransaction` request.
+    pub fn with_skip_preflight(mut self, skip_preflight: bool) -> Self {
+        self.request.params.skip_preflight = Some(skip_preflight);
+        self
+    }
+
+    /// Change the `preflightCommitment` parameter for a `sendTransaction` request.
+    pub fn with_preflight_commitment(mut self, preflight_commitment: CommitmentLevel) -> Self {
+        self.request.params.preflight_commitment = Some(preflight_commitment);
+        self
+    }
+
+    /// Change the `maxRetries` parameter for a `sendTransaction` request.
+    pub fn with_max_retries(mut self, max_retries: u32) -> Self {
+        self.request.params.max_retries = Some(max_retries);
+        self
+    }
+
+    /// Change the `minContextSlot` parameter for a `sendTransaction` request.
+    pub fn with_min_context_slot(mut self, slot: Slot) -> Self {
+        self.request.params.min_context_slot = Some(slot);
+        self
+    }
+}
 
 pub struct JsonRequest(String);
 

--- a/libs/client/src/request/tests.rs
+++ b/libs/client/src/request/tests.rs
@@ -1,15 +1,22 @@
-use crate::{SolRpcClient, SolRpcEndpoint};
+use crate::{RequestBuilder, SolRpcClient, SolRpcEndpoint};
 use serde_json::json;
 use sol_rpc_types::{
-    CommitmentLevel, GetBlockCommitmentLevel, SendTransactionEncoding, SendTransactionParams,
+    CommitmentLevel, DataSlice, GetAccountInfoEncoding, GetAccountInfoParams, GetBalanceParams,
+    GetBlockCommitmentLevel, GetBlockParams, GetSignatureStatusesParams,
+    GetSignaturesForAddressParams, GetSlotParams, GetTokenAccountBalanceParams,
+    GetTransactionEncoding, GetTransactionParams, SendTransactionEncoding, SendTransactionParams,
+    Slot, TransactionDetails,
 };
-use solana_pubkey::pubkey;
+use solana_pubkey::{pubkey, Pubkey};
 use solana_signature::Signature;
+use std::{fmt::Debug, str::FromStr};
 use strum::IntoEnumIterator;
+
+const PUBKEY: Pubkey = pubkey!("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v");
+const MIN_CONTEXT_SLOT: Slot = 1144441;
 
 #[test]
 fn should_set_correct_commitment_level() {
-    let pubkey = pubkey!("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v");
     let client_with_commitment_level = SolRpcClient::builder_for_ic()
         .with_default_commitment_level(CommitmentLevel::Confirmed)
         .build();
@@ -18,14 +25,14 @@ fn should_set_correct_commitment_level() {
     for endpoint in SolRpcEndpoint::iter() {
         match endpoint {
             SolRpcEndpoint::GetAccountInfo => {
-                let builder = client_with_commitment_level.get_account_info(pubkey);
+                let builder = client_with_commitment_level.get_account_info(PUBKEY);
                 assert_eq!(
                     builder.request.params.commitment,
                     Some(CommitmentLevel::Confirmed)
                 );
             }
             SolRpcEndpoint::GetBalance => {
-                let builder = client_with_commitment_level.get_balance(pubkey);
+                let builder = client_with_commitment_level.get_balance(PUBKEY);
                 assert_eq!(
                     builder.request.params.commitment,
                     Some(CommitmentLevel::Confirmed)
@@ -42,7 +49,7 @@ fn should_set_correct_commitment_level() {
                 // no op, GetRecentPrioritizationFees does not use commitment level
             }
             SolRpcEndpoint::GetSignaturesForAddress => {
-                let builder = client_with_commitment_level.get_signatures_for_address(pubkey);
+                let builder = client_with_commitment_level.get_signatures_for_address(PUBKEY);
                 assert_eq!(
                     builder.request.params.commitment,
                     Some(CommitmentLevel::Confirmed)
@@ -59,14 +66,14 @@ fn should_set_correct_commitment_level() {
                 );
             }
             SolRpcEndpoint::GetTokenAccountBalance => {
-                let builder = client_with_commitment_level.get_token_account_balance(pubkey);
+                let builder = client_with_commitment_level.get_token_account_balance(PUBKEY);
                 assert_eq!(
                     builder.request.params.commitment,
                     Some(CommitmentLevel::Confirmed)
                 );
             }
             SolRpcEndpoint::GetTransaction => {
-                let builder = client_with_commitment_level.get_transaction("tspfR5p1PFphquz4WzDb7qM4UhJdgQXkEZtW88BykVEdX2zL2kBT9kidwQBviKwQuA3b6GMCR1gknHvzQ3r623T".parse::<Signature>().unwrap());
+                let builder = client_with_commitment_level.get_transaction(signature());
                 assert_eq!(
                     builder.request.params.commitment,
                     Some(CommitmentLevel::Confirmed)
@@ -93,4 +100,186 @@ fn should_set_correct_commitment_level() {
             }
         }
     }
+}
+
+#[test]
+fn should_set_request_parameters() {
+    let client = SolRpcClient::builder_for_ic().build();
+
+    for endpoint in SolRpcEndpoint::iter() {
+        match endpoint {
+            SolRpcEndpoint::GetAccountInfo => assert_params_eq(
+                client
+                    .get_account_info(PUBKEY)
+                    .with_commitment(CommitmentLevel::Confirmed)
+                    .with_encoding(GetAccountInfoEncoding::Base64)
+                    .with_data_slice(DataSlice {
+                        length: 1,
+                        offset: 2,
+                    })
+                    .with_min_context_slot(MIN_CONTEXT_SLOT),
+                client
+                    .get_account_info(PUBKEY)
+                    .with_params(GetAccountInfoParams {
+                        pubkey: PUBKEY.into(),
+                        commitment: Some(CommitmentLevel::Confirmed),
+                        encoding: Some(GetAccountInfoEncoding::Base64),
+                        data_slice: Some(DataSlice {
+                            length: 1,
+                            offset: 2,
+                        }),
+                        min_context_slot: Some(MIN_CONTEXT_SLOT),
+                    }),
+            ),
+            SolRpcEndpoint::GetBalance => assert_params_eq(
+                client
+                    .get_balance(PUBKEY)
+                    .with_commitment(CommitmentLevel::Confirmed)
+                    .with_min_context_slot(MIN_CONTEXT_SLOT),
+                client.get_balance(PUBKEY).with_params(GetBalanceParams {
+                    pubkey: PUBKEY.into(),
+                    commitment: Some(CommitmentLevel::Confirmed),
+                    min_context_slot: Some(MIN_CONTEXT_SLOT),
+                }),
+            ),
+            SolRpcEndpoint::GetBlock => assert_params_eq(
+                client
+                    .get_block(123)
+                    .with_commitment(GetBlockCommitmentLevel::Confirmed)
+                    .with_max_supported_transaction_version(0)
+                    .with_transaction_details(TransactionDetails::Signatures),
+                client.get_block(123).with_params(GetBlockParams {
+                    slot: 123,
+                    commitment: Some(GetBlockCommitmentLevel::Confirmed),
+                    max_supported_transaction_version: Some(0),
+                    transaction_details: Some(TransactionDetails::Signatures),
+                }),
+            ),
+            SolRpcEndpoint::GetRecentPrioritizationFees => {
+                // No optional request parameters
+            }
+            SolRpcEndpoint::GetSignaturesForAddress => assert_params_eq(
+                client
+                    .get_signatures_for_address(PUBKEY)
+                    .with_commitment(CommitmentLevel::Confirmed)
+                    .with_min_context_slot(MIN_CONTEXT_SLOT)
+                    .with_limit(456.try_into().unwrap())
+                    .with_before(signature())
+                    .with_until(another_signature()),
+                client.get_signatures_for_address(PUBKEY).with_params(
+                    GetSignaturesForAddressParams {
+                        pubkey: PUBKEY.into(),
+                        commitment: Some(CommitmentLevel::Confirmed),
+                        min_context_slot: Some(MIN_CONTEXT_SLOT),
+                        limit: Some(456.try_into().unwrap()),
+                        before: Some(signature().into()),
+                        until: Some(another_signature().into()),
+                    },
+                ),
+            ),
+            SolRpcEndpoint::GetSignatureStatuses => assert_params_eq(
+                client
+                    .get_signature_statuses(&[signature()])
+                    .unwrap()
+                    .with_search_transaction_history(true),
+                client
+                    .get_signature_statuses(&[signature()])
+                    .unwrap()
+                    .with_params(GetSignatureStatusesParams {
+                        signatures: vec![signature()].try_into().unwrap(),
+                        search_transaction_history: Some(true),
+                    }),
+            ),
+            SolRpcEndpoint::GetSlot => assert_params_eq(
+                client
+                    .get_slot()
+                    .with_min_context_slot(MIN_CONTEXT_SLOT)
+                    .with_commitment(CommitmentLevel::Confirmed),
+                client.get_slot().with_params(Some(GetSlotParams {
+                    commitment: Some(CommitmentLevel::Confirmed),
+                    min_context_slot: Some(MIN_CONTEXT_SLOT),
+                })),
+            ),
+            SolRpcEndpoint::GetTokenAccountBalance => assert_params_eq(
+                client
+                    .get_token_account_balance(PUBKEY)
+                    .with_commitment(CommitmentLevel::Confirmed),
+                client.get_token_account_balance(PUBKEY).with_params(
+                    GetTokenAccountBalanceParams {
+                        pubkey: PUBKEY.into(),
+                        commitment: Some(CommitmentLevel::Confirmed),
+                    },
+                ),
+            ),
+            SolRpcEndpoint::GetTransaction => assert_params_eq(
+                client
+                    .get_transaction(signature())
+                    .with_commitment(CommitmentLevel::Confirmed)
+                    .with_max_supported_transaction_version(0)
+                    .with_encoding(GetTransactionEncoding::Base64),
+                client
+                    .get_transaction(signature())
+                    .with_params(GetTransactionParams {
+                        signature: signature().into(),
+                        commitment: Some(CommitmentLevel::Confirmed),
+                        max_supported_transaction_version: Some(0),
+                        encoding: Some(GetTransactionEncoding::Base64),
+                    }),
+            ),
+            SolRpcEndpoint::JsonRequest => {
+                // No optional request parameters
+            }
+            SolRpcEndpoint::SendTransaction => assert_params_eq(
+                client
+                    .send_transaction(transaction())
+                    .with_skip_preflight(true)
+                    .with_preflight_commitment(CommitmentLevel::Confirmed)
+                    .with_max_retries(10)
+                    .with_min_context_slot(MIN_CONTEXT_SLOT),
+                client
+                    .send_transaction(transaction())
+                    .modify_params(|params| {
+                        params.skip_preflight = Some(true);
+                        params.preflight_commitment = Some(CommitmentLevel::Confirmed);
+                        params.max_retries = Some(10);
+                        params.min_context_slot = Some(MIN_CONTEXT_SLOT);
+                    }),
+            ),
+        }
+    }
+}
+
+fn assert_params_eq<Runtime, Config, Params, CandidOutput, Output>(
+    left: RequestBuilder<Runtime, Config, Params, CandidOutput, Output>,
+    right: RequestBuilder<Runtime, Config, Params, CandidOutput, Output>,
+) where
+    Params: Debug + PartialEq,
+{
+    assert_eq!(left.request.params, right.request.params);
+}
+
+fn signature() -> Signature {
+    Signature::from_str(
+        "tspfR5p1PFphquz4WzDb7qM4UhJdgQXkEZtW88BykVEdX2zL2kBT9kidwQBviKwQuA3b6GMCR1gknHvzQ3r623T",
+    )
+    .unwrap()
+}
+
+fn another_signature() -> Signature {
+    Signature::from_str(
+        "3WM42nYDQAHgBWFd6SbJ3pj1AGgiTJfxXJ2d5dHu49GgqSUui5qdh64S5yLCN1cMKcLMFVKKo776GrtVhfatLqP6",
+    )
+    .unwrap()
+}
+
+fn transaction() -> solana_transaction::Transaction {
+    let keypair = solana_keypair::Keypair::from_base58_string(
+        "3jipnj2WowKxqMaSoTj8v79kcSb5bbvJHomd5FwycLg1juPnWdhJBzszABAAxVEfRmsxdo2bnbi7hpag3CrLNU1c",
+    );
+    solana_transaction::Transaction::new_signed_with_payer(
+        &[],
+        Some(&pubkey!("3HwVowmCYKPWjRvkqfEfYFWetZLPmZW6LCnLEQDHqpJJ")),
+        &[keypair],
+        solana_hash::Hash::from_str("4Pcj2yJkCYyhnWe8Ze3uK2D2EtesBxhAevweDoTcxXf3").unwrap(),
+    )
 }

--- a/libs/types/src/lib.rs
+++ b/libs/types/src/lib.rs
@@ -50,17 +50,24 @@ pub use solana::{
 #[serde(try_from = "Vec<T>")]
 pub struct VecWithMaxLen<T, const CAPACITY: usize>(Vec<T>);
 
-impl<T, const CAPACITY: usize> TryFrom<Vec<T>> for VecWithMaxLen<T, CAPACITY> {
+impl<T, const CAPACITY: usize> VecWithMaxLen<T, CAPACITY> {
+    /// Constructs a new, empty `VecWithMaxLen<T, CAPACITY>`.
+    pub fn new() -> Self {
+        Self(Vec::new())
+    }
+}
+
+impl<S: Into<T>, T, const CAPACITY: usize> TryFrom<Vec<S>> for VecWithMaxLen<T, CAPACITY> {
     type Error = RpcError;
 
-    fn try_from(value: Vec<T>) -> Result<Self, Self::Error> {
+    fn try_from(value: Vec<S>) -> Result<Self, Self::Error> {
         if value.len() > CAPACITY {
             return Err(RpcError::ValidationError(format!(
                 "Expected at most {CAPACITY} items, but got {}",
                 value.len()
             )));
         }
-        Ok(Self(value))
+        Ok(Self(value.into_iter().map(Into::into).collect()))
     }
 }
 

--- a/libs/types/src/lib.rs
+++ b/libs/types/src/lib.rs
@@ -46,7 +46,7 @@ pub use solana::{
 };
 
 /// A vector with a maximum capacity.
-#[derive(Debug, Clone, Deserialize, CandidType, PartialEq, Default, Into)]
+#[derive(Clone, Debug, Default, PartialEq, CandidType, Deserialize, Into)]
 #[serde(try_from = "Vec<T>")]
 pub struct VecWithMaxLen<T, const CAPACITY: usize>(Vec<T>);
 

--- a/libs/types/src/solana/request/mod.rs
+++ b/libs/types/src/solana/request/mod.rs
@@ -7,7 +7,7 @@ use candid::{CandidType, Deserialize};
 use serde::Serialize;
 
 /// The parameters for a Solana [`getAccountInfo`](https://solana.com/docs/rpc/http/getaccountinfo) RPC method call.
-#[derive(Debug, Clone, Deserialize, Serialize, CandidType)]
+#[derive(Debug, Clone, Deserialize, Serialize, CandidType, PartialEq)]
 pub struct GetAccountInfoParams {
     /// The public key of the account whose info to fetch formatted as a base-58 string.
     pub pubkey: Pubkey,
@@ -58,7 +58,7 @@ impl From<solana_pubkey::Pubkey> for GetAccountInfoParams {
 }
 
 /// Encoding for the return value of the Solana [`getAccountInfo`](https://solana.com/docs/rpc/http/getaccountinfo) RPC method.
-#[derive(Debug, Clone, Deserialize, Serialize, CandidType)]
+#[derive(Debug, Clone, Deserialize, Serialize, CandidType, PartialEq)]
 pub enum GetAccountInfoEncoding {
     /// The account data is base-58 encoded. Limited to less than 129 bytes of data.
     #[serde(rename = "base58")]
@@ -78,7 +78,7 @@ pub enum GetAccountInfoEncoding {
 }
 
 /// Represents a slice of the return value of the Solana [`getAccountInfo`](https://solana.com/docs/rpc/http/getAccountInfo) RPC method.
-#[derive(Debug, Clone, Default, Deserialize, Serialize, CandidType)]
+#[derive(Debug, Clone, Default, Deserialize, Serialize, CandidType, PartialEq)]
 pub struct DataSlice {
     /// Number of bytes to return.
     pub length: u32,
@@ -87,7 +87,7 @@ pub struct DataSlice {
 }
 
 /// The parameters for a Solana [`getBalance`](https://solana.com/docs/rpc/http/getbalance) RPC method call.
-#[derive(Debug, Clone, Deserialize, Serialize, CandidType)]
+#[derive(Debug, Clone, Deserialize, Serialize, CandidType, PartialEq)]
 pub struct GetBalanceParams {
     /// The public key of the account to query formatted as a base-58 string.
     pub pubkey: Pubkey,
@@ -117,7 +117,7 @@ impl From<solana_pubkey::Pubkey> for GetBalanceParams {
 
 /// The parameters for a Solana [`getBlock`](https://solana.com/docs/rpc/http/getblock) RPC method call.
 // TODO XC-342: Add `rewards`, `encoding` and `transactionDetails` fields.
-#[derive(Debug, Clone, Default, Deserialize, Serialize, CandidType)]
+#[derive(Debug, Clone, Default, Deserialize, Serialize, CandidType, PartialEq)]
 pub struct GetBlockParams {
     /// Slot number of the block to fetch.
     pub slot: Slot,
@@ -172,7 +172,7 @@ impl From<Slot> for GetBlockParams {
 /// will be used, which is different from the default value in the Solana RPC API. This is
 /// because the default value of `full` for the Solana RPC API results in response sizes that
 /// are generally too large to be supported by the ICP.
-#[derive(Debug, Clone, Copy, Default, Deserialize, Serialize, CandidType)]
+#[derive(Debug, Clone, Copy, Default, Deserialize, Serialize, CandidType, PartialEq)]
 pub enum TransactionDetails {
     /// Includes transaction signatures (IDs) and block metadata only.
     #[serde(rename = "signatures")]
@@ -214,7 +214,7 @@ impl From<GetRecentPrioritizationFeesParams> for Vec<Pubkey> {
 }
 
 /// The parameters for a Solana [`getSignaturesForAddress`](https://solana.com/docs/rpc/http/getsignaturesforaddress) RPC method call.
-#[derive(Debug, Clone, Deserialize, Serialize, CandidType)]
+#[derive(Debug, Clone, Deserialize, Serialize, CandidType, PartialEq)]
 pub struct GetSignaturesForAddressParams {
     /// The account address.
     pub pubkey: Pubkey,
@@ -254,7 +254,7 @@ impl<P: Into<Pubkey>> From<P> for GetSignaturesForAddressParams {
 
 /// The maximum number of transactions to return in the response of a
 /// [`getSignaturesForAddress`](https://solana.com/docs/rpc/http/getsignaturesforaddress) request.
-#[derive(Debug, Clone, Copy, Deserialize, Serialize, CandidType)]
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, CandidType, PartialEq)]
 #[serde(try_from = "u32", into = "u32")]
 pub struct GetSignaturesForAddressLimit(u32);
 
@@ -291,7 +291,7 @@ impl From<GetSignaturesForAddressLimit> for u32 {
 }
 
 /// The parameters for a Solana [`getSignatureStatuses`](https://solana.com/docs/rpc/http/getsignaturestatuses) RPC method call.
-#[derive(Debug, Clone, Default, Deserialize, Serialize, CandidType)]
+#[derive(Debug, Clone, Default, Deserialize, Serialize, CandidType, PartialEq)]
 pub struct GetSignatureStatusesParams {
     /// An array of transaction signatures to confirm, as base-58 encoded strings (up to a maximum of 256)
     pub signatures: VecWithMaxLen<Signature, 256>,
@@ -316,7 +316,7 @@ impl<S: Into<Signature>> TryFrom<Vec<S>> for GetSignatureStatusesParams {
 }
 
 /// The parameters for a Solana [`getSlot`](https://solana.com/docs/rpc/http/getslot) RPC method call.
-#[derive(Debug, Clone, Default, Deserialize, Serialize, CandidType)]
+#[derive(Debug, Clone, Default, Deserialize, Serialize, CandidType, PartialEq)]
 pub struct GetSlotParams {
     /// The request returns the slot that has reached this or the default commitment level.
     pub commitment: Option<CommitmentLevel>,
@@ -337,7 +337,7 @@ impl GetSlotParams {
 }
 
 /// The parameters for a Solana [`getTokenAccountBalance`](https://solana.com/docs/rpc/http/gettokenaccountbalance) RPC method call.
-#[derive(Debug, Clone, Deserialize, Serialize, CandidType)]
+#[derive(Debug, Clone, Deserialize, Serialize, CandidType, PartialEq)]
 pub struct GetTokenAccountBalanceParams {
     /// The public key of the token account to query formatted as a base-58 string.
     pub pubkey: Pubkey,
@@ -362,7 +362,7 @@ impl From<solana_pubkey::Pubkey> for GetTokenAccountBalanceParams {
 }
 
 /// The parameters for a Solana [`getTransaction`](https://solana.com/docs/rpc/http/gettransaction) RPC method call.
-#[derive(Debug, Clone, Deserialize, Serialize, CandidType)]
+#[derive(Debug, Clone, Deserialize, Serialize, CandidType, PartialEq)]
 pub struct GetTransactionParams {
     /// Transaction signature.
     pub signature: Signature,
@@ -407,7 +407,7 @@ impl From<solana_signature::Signature> for GetTransactionParams {
 /// Encoding format for the returned transaction from a [`getTransaction`](https://solana.com/docs/rpc/http/gettransaction)`
 /// RPC method call.
 // TODO XC-343: Add support for `json` and `jsonParsed` formats.
-#[derive(Debug, Clone, Deserialize, Serialize, CandidType)]
+#[derive(Debug, Clone, Deserialize, Serialize, CandidType, PartialEq)]
 pub enum GetTransactionEncoding {
     /// The transaction is base64-encoded.
     #[serde(rename = "base64")]
@@ -418,7 +418,7 @@ pub enum GetTransactionEncoding {
 }
 
 /// The parameters for a Solana [`sendTransaction`](https://solana.com/docs/rpc/http/sendtransaction) RPC method call.
-#[derive(Debug, Clone, Deserialize, Serialize, CandidType)]
+#[derive(Debug, Clone, Deserialize, Serialize, CandidType, PartialEq)]
 pub struct SendTransactionParams {
     /// Fully-signed transaction, as encoded string.
     transaction: String,
@@ -501,7 +501,7 @@ impl TryFrom<solana_transaction::Transaction> for SendTransactionParams {
 
 /// The encoding format for the transaction argument to the Solana
 /// [`sendTransaction`](https://solana.com/docs/rpc/http/sendtransaction) RPC method call.
-#[derive(Debug, Clone, Deserialize, Serialize, CandidType)]
+#[derive(Debug, Clone, Deserialize, Serialize, CandidType, PartialEq)]
 pub enum SendTransactionEncoding {
     /// The transaction is base-58 encoded (slow, deprecated).
     #[serde(rename = "base58")]

--- a/libs/types/src/solana/request/mod.rs
+++ b/libs/types/src/solana/request/mod.rs
@@ -7,7 +7,7 @@ use candid::{CandidType, Deserialize};
 use serde::Serialize;
 
 /// The parameters for a Solana [`getAccountInfo`](https://solana.com/docs/rpc/http/getaccountinfo) RPC method call.
-#[derive(Debug, Clone, Deserialize, Serialize, CandidType, PartialEq)]
+#[derive(Clone, Debug, PartialEq, CandidType, Deserialize, Serialize)]
 pub struct GetAccountInfoParams {
     /// The public key of the account whose info to fetch formatted as a base-58 string.
     pub pubkey: Pubkey,
@@ -58,7 +58,7 @@ impl From<solana_pubkey::Pubkey> for GetAccountInfoParams {
 }
 
 /// Encoding for the return value of the Solana [`getAccountInfo`](https://solana.com/docs/rpc/http/getaccountinfo) RPC method.
-#[derive(Debug, Clone, Deserialize, Serialize, CandidType, PartialEq)]
+#[derive(Clone, Debug, PartialEq, CandidType, Deserialize, Serialize)]
 pub enum GetAccountInfoEncoding {
     /// The account data is base-58 encoded. Limited to less than 129 bytes of data.
     #[serde(rename = "base58")]
@@ -78,7 +78,7 @@ pub enum GetAccountInfoEncoding {
 }
 
 /// Represents a slice of the return value of the Solana [`getAccountInfo`](https://solana.com/docs/rpc/http/getAccountInfo) RPC method.
-#[derive(Debug, Clone, Default, Deserialize, Serialize, CandidType, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq, CandidType, Deserialize, Serialize)]
 pub struct DataSlice {
     /// Number of bytes to return.
     pub length: u32,
@@ -87,7 +87,7 @@ pub struct DataSlice {
 }
 
 /// The parameters for a Solana [`getBalance`](https://solana.com/docs/rpc/http/getbalance) RPC method call.
-#[derive(Debug, Clone, Deserialize, Serialize, CandidType, PartialEq)]
+#[derive(Clone, Debug, PartialEq, CandidType, Deserialize, Serialize)]
 pub struct GetBalanceParams {
     /// The public key of the account to query formatted as a base-58 string.
     pub pubkey: Pubkey,
@@ -117,7 +117,7 @@ impl From<solana_pubkey::Pubkey> for GetBalanceParams {
 
 /// The parameters for a Solana [`getBlock`](https://solana.com/docs/rpc/http/getblock) RPC method call.
 // TODO XC-342: Add `rewards`, `encoding` and `transactionDetails` fields.
-#[derive(Debug, Clone, Default, Deserialize, Serialize, CandidType, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq, CandidType, Deserialize, Serialize)]
 pub struct GetBlockParams {
     /// Slot number of the block to fetch.
     pub slot: Slot,
@@ -172,7 +172,7 @@ impl From<Slot> for GetBlockParams {
 /// will be used, which is different from the default value in the Solana RPC API. This is
 /// because the default value of `full` for the Solana RPC API results in response sizes that
 /// are generally too large to be supported by the ICP.
-#[derive(Debug, Clone, Copy, Default, Deserialize, Serialize, CandidType, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, CandidType, Deserialize, Serialize)]
 pub enum TransactionDetails {
     /// Includes transaction signatures (IDs) and block metadata only.
     #[serde(rename = "signatures")]
@@ -184,7 +184,7 @@ pub enum TransactionDetails {
 }
 
 /// The parameters for a Solana [`getRecentPrioritizationFees`](https://solana.com/de/docs/rpc/http/getrecentprioritizationfees) RPC method call.
-#[derive(Debug, Clone, Default, Deserialize, Serialize, CandidType)]
+#[derive(Clone, Debug, Default, CandidType, Deserialize, Serialize)]
 pub struct GetRecentPrioritizationFeesParams(VecWithMaxLen<Pubkey, 128>);
 
 impl<P: Into<Pubkey>> TryFrom<Vec<P>> for GetRecentPrioritizationFeesParams {
@@ -214,7 +214,7 @@ impl From<GetRecentPrioritizationFeesParams> for Vec<Pubkey> {
 }
 
 /// The parameters for a Solana [`getSignaturesForAddress`](https://solana.com/docs/rpc/http/getsignaturesforaddress) RPC method call.
-#[derive(Debug, Clone, Deserialize, Serialize, CandidType, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq, CandidType, Deserialize, Serialize)]
 pub struct GetSignaturesForAddressParams {
     /// The account address.
     pub pubkey: Pubkey,
@@ -254,7 +254,7 @@ impl<P: Into<Pubkey>> From<P> for GetSignaturesForAddressParams {
 
 /// The maximum number of transactions to return in the response of a
 /// [`getSignaturesForAddress`](https://solana.com/docs/rpc/http/getsignaturesforaddress) request.
-#[derive(Debug, Clone, Copy, Deserialize, Serialize, CandidType, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, CandidType, Deserialize, Serialize)]
 #[serde(try_from = "u32", into = "u32")]
 pub struct GetSignaturesForAddressLimit(u32);
 
@@ -291,7 +291,7 @@ impl From<GetSignaturesForAddressLimit> for u32 {
 }
 
 /// The parameters for a Solana [`getSignatureStatuses`](https://solana.com/docs/rpc/http/getsignaturestatuses) RPC method call.
-#[derive(Debug, Clone, Default, Deserialize, Serialize, CandidType, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq, CandidType, Deserialize, Serialize)]
 pub struct GetSignatureStatusesParams {
     /// An array of transaction signatures to confirm, as base-58 encoded strings (up to a maximum of 256)
     pub signatures: VecWithMaxLen<Signature, 256>,
@@ -316,7 +316,7 @@ impl<S: Into<Signature>> TryFrom<Vec<S>> for GetSignatureStatusesParams {
 }
 
 /// The parameters for a Solana [`getSlot`](https://solana.com/docs/rpc/http/getslot) RPC method call.
-#[derive(Debug, Clone, Default, Deserialize, Serialize, CandidType, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq, CandidType, Deserialize, Serialize)]
 pub struct GetSlotParams {
     /// The request returns the slot that has reached this or the default commitment level.
     pub commitment: Option<CommitmentLevel>,
@@ -337,7 +337,7 @@ impl GetSlotParams {
 }
 
 /// The parameters for a Solana [`getTokenAccountBalance`](https://solana.com/docs/rpc/http/gettokenaccountbalance) RPC method call.
-#[derive(Debug, Clone, Deserialize, Serialize, CandidType, PartialEq)]
+#[derive(Clone, Debug, PartialEq, CandidType, Deserialize, Serialize)]
 pub struct GetTokenAccountBalanceParams {
     /// The public key of the token account to query formatted as a base-58 string.
     pub pubkey: Pubkey,
@@ -362,7 +362,7 @@ impl From<solana_pubkey::Pubkey> for GetTokenAccountBalanceParams {
 }
 
 /// The parameters for a Solana [`getTransaction`](https://solana.com/docs/rpc/http/gettransaction) RPC method call.
-#[derive(Debug, Clone, Deserialize, Serialize, CandidType, PartialEq)]
+#[derive(Clone, Debug, PartialEq, CandidType, Deserialize, Serialize)]
 pub struct GetTransactionParams {
     /// Transaction signature.
     pub signature: Signature,
@@ -407,7 +407,7 @@ impl From<solana_signature::Signature> for GetTransactionParams {
 /// Encoding format for the returned transaction from a [`getTransaction`](https://solana.com/docs/rpc/http/gettransaction)`
 /// RPC method call.
 // TODO XC-343: Add support for `json` and `jsonParsed` formats.
-#[derive(Debug, Clone, Deserialize, Serialize, CandidType, PartialEq)]
+#[derive(Clone, Debug, PartialEq, CandidType, Deserialize, Serialize)]
 pub enum GetTransactionEncoding {
     /// The transaction is base64-encoded.
     #[serde(rename = "base64")]
@@ -418,7 +418,7 @@ pub enum GetTransactionEncoding {
 }
 
 /// The parameters for a Solana [`sendTransaction`](https://solana.com/docs/rpc/http/sendtransaction) RPC method call.
-#[derive(Debug, Clone, Deserialize, Serialize, CandidType, PartialEq)]
+#[derive(Clone, Debug, PartialEq, CandidType, Deserialize, Serialize)]
 pub struct SendTransactionParams {
     /// Fully-signed transaction, as encoded string.
     transaction: String,
@@ -501,7 +501,7 @@ impl TryFrom<solana_transaction::Transaction> for SendTransactionParams {
 
 /// The encoding format for the transaction argument to the Solana
 /// [`sendTransaction`](https://solana.com/docs/rpc/http/sendtransaction) RPC method call.
-#[derive(Debug, Clone, Deserialize, Serialize, CandidType, PartialEq)]
+#[derive(Clone, Debug, PartialEq, CandidType, Deserialize, Serialize)]
 pub enum SendTransactionEncoding {
     /// The transaction is base-58 encoded (slow, deprecated).
     #[serde(rename = "base58")]
@@ -513,7 +513,7 @@ pub enum SendTransactionEncoding {
 
 /// [Commitment levels](https://solana.com/docs/rpc#configuring-state-commitment) in Solana,
 /// representing finality guarantees of transactions and memory queries.
-#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize, CandidType)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, CandidType, Deserialize, Serialize)]
 pub enum CommitmentLevel {
     /// The transaction is processed by a leader, but may be dropped.
     #[serde(rename = "processed")]
@@ -539,7 +539,7 @@ impl From<CommitmentLevel> for solana_commitment_config::CommitmentConfig {
 
 /// Subset of [`CommitmentLevel`] whose variants are allowed values for the `encoding`
 /// field of [`GetBlockParams`].
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize, CandidType)]
+#[derive(Clone, Debug, Eq, PartialEq, CandidType, Deserialize, Serialize)]
 pub enum GetBlockCommitmentLevel {
     /// See [`CommitmentLevel::Confirmed`].
     #[serde(rename = "confirmed")]


### PR DESCRIPTION
Add explicit types for all RPC request builders, and methods to set optional request parameters (e.g. `with_min_context_slot()`, `.with_commitment()`).