### PR TITLE
refactor: inline request parameters `is_default_config` methods

### DIFF
--- a/canister/src/rpc_client/json/mod.rs
+++ b/canister/src/rpc_client/json/mod.rs
@@ -15,12 +15,16 @@ pub struct GetSlotParams(Option<GetSlotConfig>);
 
 impl From<sol_rpc_types::GetSlotParams> for GetSlotParams {
     fn from(params: sol_rpc_types::GetSlotParams) -> Self {
-        let config = if params.is_default_config() {
+        let sol_rpc_types::GetSlotParams {
+            commitment,
+            min_context_slot,
+        } = params;
+        let config = if commitment.is_none() && min_context_slot.is_none() {
             None
         } else {
             Some(GetSlotConfig {
-                commitment: params.commitment,
-                min_context_slot: params.min_context_slot,
+                commitment,
+                min_context_slot,
             })
         };
         Self(config)
@@ -48,17 +52,28 @@ pub struct GetAccountInfoParams(String, Option<GetAccountInfoConfig>);
 
 impl From<sol_rpc_types::GetAccountInfoParams> for GetAccountInfoParams {
     fn from(params: sol_rpc_types::GetAccountInfoParams) -> Self {
-        let config = if params.is_default_config() {
+        let sol_rpc_types::GetAccountInfoParams {
+            pubkey,
+            commitment,
+            encoding,
+            data_slice,
+            min_context_slot,
+        } = params;
+        let config = if commitment.is_none()
+            && encoding.is_none()
+            && data_slice.is_none()
+            && min_context_slot.is_none()
+        {
             None
         } else {
             Some(GetAccountInfoConfig {
-                commitment: params.commitment,
-                encoding: params.encoding,
-                data_slice: params.data_slice,
-                min_context_slot: params.min_context_slot,
+                commitment,
+                encoding,
+                data_slice,
+                min_context_slot,
             })
         };
-        Self(params.pubkey.to_string(), config)
+        Self(pubkey.to_string(), config)
     }
 }
 
@@ -316,16 +331,25 @@ pub struct GetTransactionParams(String, Option<GetTransactionConfig>);
 
 impl From<sol_rpc_types::GetTransactionParams> for GetTransactionParams {
     fn from(params: sol_rpc_types::GetTransactionParams) -> Self {
-        let config = if params.is_default_config() {
+        let sol_rpc_types::GetTransactionParams {
+            signature,
+            commitment,
+            max_supported_transaction_version,
+            encoding,
+        } = params;
+        let config = if commitment.is_none()
+            && max_supported_transaction_version.is_none()
+            && encoding.is_none()
+        {
             None
         } else {
             Some(GetTransactionConfig {
-                commitment: params.commitment,
-                max_supported_transaction_version: params.max_supported_transaction_version,
-                encoding: params.encoding,
+                commitment,
+                max_supported_transaction_version,
+                encoding,
             })
         };
-        Self(params.signature.to_string(), config)
+        Self(signature.to_string(), config)
     }
 }
 
@@ -352,15 +376,28 @@ pub struct SendTransactionParams(String, Option<SendTransactionConfig>);
 impl From<sol_rpc_types::SendTransactionParams> for SendTransactionParams {
     fn from(params: sol_rpc_types::SendTransactionParams) -> Self {
         let transaction = params.get_transaction().to_string();
-        let config = if params.is_default_config() {
+        let encoding = params.get_encoding().cloned();
+        let sol_rpc_types::SendTransactionParams {
+            skip_preflight,
+            preflight_commitment,
+            max_retries,
+            min_context_slot,
+            ..
+        } = params;
+        let config = if encoding.is_none()
+            && skip_preflight.is_none()
+            && preflight_commitment.is_none()
+            && max_retries.is_none()
+            && min_context_slot.is_none()
+        {
             None
         } else {
             Some(SendTransactionConfig {
-                encoding: params.get_encoding().cloned(),
-                skip_preflight: params.skip_preflight,
-                preflight_commitment: params.preflight_commitment,
-                max_retries: params.max_retries,
-                min_context_slot: params.min_context_slot,
+                encoding,
+                skip_preflight,
+                preflight_commitment,
+                max_retries,
+                min_context_slot,
             })
         };
         Self(transaction, config)

--- a/libs/types/src/solana/request/mod.rs
+++ b/libs/types/src/solana/request/mod.rs
@@ -295,8 +295,6 @@ pub struct GetSlotParams {
     pub min_context_slot: Option<Slot>,
 }
 
-impl GetSlotParams {}
-
 /// The parameters for a Solana [`getTokenAccountBalance`](https://solana.com/docs/rpc/http/gettokenaccountbalance) RPC method call.
 #[derive(Clone, Debug, PartialEq, CandidType, Deserialize, Serialize)]
 pub struct GetTokenAccountBalanceParams {
@@ -340,8 +338,6 @@ pub struct GetTransactionParams {
     // TODO XC-343: Add notes about `jsonParsed` from https://solana.com/de/docs/rpc/http/gettransaction
     pub encoding: Option<GetTransactionEncoding>,
 }
-
-impl GetTransactionParams {}
 
 impl From<solana_signature::Signature> for GetTransactionParams {
     fn from(signature: solana_signature::Signature) -> Self {

--- a/libs/types/src/solana/request/mod.rs
+++ b/libs/types/src/solana/request/mod.rs
@@ -24,21 +24,6 @@ pub struct GetAccountInfoParams {
 }
 
 impl GetAccountInfoParams {
-    /// Returns `true` if all of the optional config parameters are `None` and `false` otherwise.
-    pub fn is_default_config(&self) -> bool {
-        let GetAccountInfoParams {
-            pubkey: _,
-            commitment,
-            encoding,
-            data_slice,
-            min_context_slot,
-        } = &self;
-        commitment.is_none()
-            && encoding.is_none()
-            && data_slice.is_none()
-            && min_context_slot.is_none()
-    }
-
     /// Parameters for a `getAccountInfo` request with the given pubkey.
     pub fn from_pubkey<P: Into<Pubkey>>(pubkey: P) -> Self {
         Self {
@@ -138,21 +123,6 @@ pub struct GetBlockParams {
     /// are generally too large to be supported by the ICP.
     #[serde(rename = "transactionDetails")]
     pub transaction_details: Option<TransactionDetails>,
-}
-
-impl GetBlockParams {
-    /// Returns `true` if all of the optional config parameters are `None` and `false` otherwise.
-    pub fn is_default_config(&self) -> bool {
-        let GetBlockParams {
-            slot: _,
-            commitment,
-            max_supported_transaction_version,
-            transaction_details,
-        } = &self;
-        commitment.is_none()
-            && max_supported_transaction_version.is_none()
-            && transaction_details.is_none()
-    }
 }
 
 impl From<Slot> for GetBlockParams {
@@ -325,16 +295,7 @@ pub struct GetSlotParams {
     pub min_context_slot: Option<Slot>,
 }
 
-impl GetSlotParams {
-    /// Returns `true` if all of the optional config parameters are `None` and `false` otherwise.
-    pub fn is_default_config(&self) -> bool {
-        let GetSlotParams {
-            commitment,
-            min_context_slot,
-        } = &self;
-        commitment.is_none() && min_context_slot.is_none()
-    }
-}
+impl GetSlotParams {}
 
 /// The parameters for a Solana [`getTokenAccountBalance`](https://solana.com/docs/rpc/http/gettokenaccountbalance) RPC method call.
 #[derive(Clone, Debug, PartialEq, CandidType, Deserialize, Serialize)]
@@ -380,18 +341,7 @@ pub struct GetTransactionParams {
     pub encoding: Option<GetTransactionEncoding>,
 }
 
-impl GetTransactionParams {
-    /// Returns `true` if all of the optional config parameters are `None` and `false` otherwise.
-    pub fn is_default_config(&self) -> bool {
-        let GetTransactionParams {
-            signature: _,
-            commitment,
-            max_supported_transaction_version,
-            encoding,
-        } = &self;
-        commitment.is_none() && max_supported_transaction_version.is_none() && encoding.is_none()
-    }
-}
+impl GetTransactionParams {}
 
 impl From<solana_signature::Signature> for GetTransactionParams {
     fn from(signature: solana_signature::Signature) -> Self {
@@ -455,23 +405,6 @@ impl SendTransactionParams {
             max_retries: None,
             min_context_slot: None,
         }
-    }
-
-    /// Returns `true` if all of the optional config parameters are `None` and `false` otherwise.
-    pub fn is_default_config(&self) -> bool {
-        let SendTransactionParams {
-            transaction: _,
-            encoding,
-            skip_preflight,
-            preflight_commitment,
-            max_retries,
-            min_context_slot,
-        } = &self;
-        encoding.is_none()
-            && skip_preflight.is_none()
-            && preflight_commitment.is_none()
-            && max_retries.is_none()
-            && min_context_slot.is_none()
     }
 
     /// The transaction being sent as an encoded string.


### PR DESCRIPTION
Inline the public `is_default_config()` method for various request parameters that were only used when serializing said request parameters.