### PR TITLE
refactor: change `Runtime` trait to use `&mut self` references

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4480,6 +4480,7 @@ dependencies = [
  "bincode",
  "candid",
  "derive_more",
+ "futures",
  "ic-cdk",
  "ic-ed25519",
  "serde",

--- a/end_to_end_tests/src/lib.rs
+++ b/end_to_end_tests/src/lib.rs
@@ -211,7 +211,7 @@ impl<'a> IcAgentRuntime<'a> {
 #[async_trait]
 impl Runtime for IcAgentRuntime<'_> {
     async fn update_call<In, Out>(
-        &self,
+        &mut self,
         id: Principal,
         method: &str,
         args: In,
@@ -233,7 +233,7 @@ impl Runtime for IcAgentRuntime<'_> {
     }
 
     async fn query_call<In, Out>(
-        &self,
+        &mut self,
         id: Principal,
         method: &str,
         args: In,

--- a/examples/basic_solana/src/ed25519.rs
+++ b/examples/basic_solana/src/ed25519.rs
@@ -31,7 +31,7 @@ pub async fn get_ed25519_public_key(
     derivation_path: &DerivationPath,
 ) -> Ed25519ExtendedPublicKey {
     let (pubkey, chain_code) = sol_rpc_client::ed25519::get_pubkey(
-        &IcRuntime,
+        &mut IcRuntime,
         None,
         Some(derivation_path),
         key_name.into(),

--- a/examples/basic_solana/src/solana_wallet.rs
+++ b/examples/basic_solana/src/solana_wallet.rs
@@ -42,7 +42,7 @@ impl SolanaAccount {
 
     pub async fn sign_message(&self, message: &Message) -> Signature {
         sign_message(
-            &IcRuntime,
+            &mut IcRuntime,
             message,
             read_state(|s| s.ed25519_key_name()).into(),
             Some(&self.derivation_path),

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -150,8 +150,7 @@ impl Setup {
     }
 
     pub async fn verify_api_key(&self, api_key: (SupportedRpcProviderId, Option<String>)) {
-        let runtime = self.new_pocket_ic_runtime();
-        runtime
+        self.new_pocket_ic_runtime()
             .query_call(self.sol_rpc_canister_id, "verifyApiKey", (api_key,))
             .await
             .unwrap()
@@ -164,8 +163,8 @@ impl Setup {
             headers: vec![],
             body: serde_bytes::ByteBuf::new(),
         };
-        let runtime = self.new_pocket_ic_runtime();
-        let response: HttpResponse = runtime
+        let response: HttpResponse = self
+            .new_pocket_ic_runtime()
             .query_call(self.sol_rpc_canister_id, "http_request", (request,))
             .await
             .unwrap();
@@ -274,7 +273,7 @@ pub struct PocketIcRuntime<'a> {
 #[async_trait]
 impl Runtime for PocketIcRuntime<'_> {
     async fn update_call<In, Out>(
-        &self,
+        &mut self,
         id: Principal,
         method: &str,
         args: In,
@@ -305,7 +304,7 @@ impl Runtime for PocketIcRuntime<'_> {
     }
 
     async fn query_call<In, Out>(
-        &self,
+        &mut self,
         id: Principal,
         method: &str,
         args: In,
@@ -424,7 +423,7 @@ pub struct PocketIcLiveModeRuntime<'a> {
 #[async_trait]
 impl Runtime for PocketIcLiveModeRuntime<'_> {
     async fn update_call<In, Out>(
-        &self,
+        &mut self,
         id: Principal,
         method: &str,
         args: In,
@@ -454,7 +453,7 @@ impl Runtime for PocketIcLiveModeRuntime<'_> {
     }
 
     async fn query_call<In, Out>(
-        &self,
+        &mut self,
         id: Principal,
         method: &str,
         args: In,

--- a/libs/client/Cargo.toml
+++ b/libs/client/Cargo.toml
@@ -36,6 +36,7 @@ solana-transaction-status-client-types = { workspace = true }
 sol_rpc_types = { version = "0.2.0", path = "../types" }
 strum = { workspace = true }
 thiserror = { workspace = true }
+futures = "0.3.31"
 
 [features]
 ed25519 = [

--- a/libs/client/src/ed25519.rs
+++ b/libs/client/src/ed25519.rs
@@ -91,8 +91,8 @@ impl Ed25519KeyId {
 /// # use sol_rpc_client::fixtures::MockRuntime;
 /// # use std::str::FromStr;
 /// # use ic_cdk::api::management_canister::schnorr::{SchnorrPublicKeyResponse, SignWithSchnorrResponse};
-/// let runtime = IcRuntime;
-/// # let runtime = MockRuntime::same_response(SchnorrPublicKeyResponse {
+/// let mut runtime = IcRuntime;
+/// # let mut runtime = MockRuntime::same_response(SchnorrPublicKeyResponse {
 /// #     public_key: pubkey!("BPebStjcgCPnWTK3FXZJ8KhqwNYLk9aubC9b4Cgqb6oE").as_ref().to_vec(),
 /// #     chain_code: "UWbC6EgDnWEJIU4KFBqASTCYAzEiJGsR".as_bytes().to_vec(),
 /// # });
@@ -102,7 +102,7 @@ impl Ed25519KeyId {
 ///     Principal::from_text("vaupb-eqaaa-aaaai-qplka-cai").unwrap()
 /// );
 /// let (payer, _) = get_pubkey(
-///     &runtime,
+///     &mut runtime,
 ///     None,
 ///     Some(&derivation_path),
 ///     key_id
@@ -120,11 +120,11 @@ impl Ed25519KeyId {
 ///     &recent_blockhash,
 ///  );
 ///
-/// # let runtime = MockRuntime::same_response(SignWithSchnorrResponse {
+/// # let mut runtime = MockRuntime::same_response(SignWithSchnorrResponse {
 /// #     signature: Signature::from_str("37HbmunhjSC1xxnVsaFX2xaS8gYnb5JYiLy9B51Ky9Up69aF7Qra6dHSLMCaiurRYq3Y8ZxSVUwC5sntziWuhZee").unwrap().as_ref().to_vec(),
 /// # });
 /// let signature = sign_message(
-///     &runtime,
+///     &mut runtime,
 ///     &message,
 ///     key_id,
 ///     Some(&derivation_path),
@@ -144,7 +144,7 @@ impl Ed25519KeyId {
 /// # }
 /// ```
 pub async fn sign_message<R: Runtime>(
-    runtime: &R,
+    runtime: &mut R,
     message: &solana_message::Message,
     key_id: Ed25519KeyId,
     derivation_path: Option<&DerivationPath>,
@@ -157,19 +157,19 @@ pub async fn sign_message<R: Runtime>(
             name: key_id.id().to_string(),
         },
     };
-    let response: SignWithSchnorrResponse = R::update_call(
-        runtime,
-        Principal::management_canister(),
-        "sign_with_schnorr",
-        (arg,),
-        match key_id {
-            Ed25519KeyId::LocalDevelopment | Ed25519KeyId::MainnetTestKey1 => {
-                SIGN_WITH_SCHNORR_TEST_FEE
-            }
-            Ed25519KeyId::MainnetProdKey1 => SIGN_WITH_SCHNORR_PRODUCTION_FEE,
-        },
-    )
-    .await?;
+    let response: SignWithSchnorrResponse = runtime
+        .update_call(
+            Principal::management_canister(),
+            "sign_with_schnorr",
+            (arg,),
+            match key_id {
+                Ed25519KeyId::LocalDevelopment | Ed25519KeyId::MainnetTestKey1 => {
+                    SIGN_WITH_SCHNORR_TEST_FEE
+                }
+                Ed25519KeyId::MainnetProdKey1 => SIGN_WITH_SCHNORR_PRODUCTION_FEE,
+            },
+        )
+        .await?;
     solana_signature::Signature::try_from(response.signature).map_err(|e| {
         panic!(
             "Expected signature to contain 64 bytes, got {} bytes",
@@ -196,7 +196,7 @@ pub async fn sign_message<R: Runtime>(
 /// # use sol_rpc_client::fixtures::MockRuntime;
 /// # use ic_cdk::api::management_canister::schnorr::{SchnorrPublicKeyResponse, SignWithSchnorrResponse};
 /// let runtime = IcRuntime;
-/// # let runtime = MockRuntime::same_response(SchnorrPublicKeyResponse {
+/// # let mut runtime = MockRuntime::same_response(SchnorrPublicKeyResponse {
 /// #     public_key: pubkey!("BPebStjcgCPnWTK3FXZJ8KhqwNYLk9aubC9b4Cgqb6oE").as_ref().to_vec(),
 /// #     chain_code: "UWbC6EgDnWEJIU4KFBqASTCYAzEiJGsR".as_bytes().to_vec(),
 /// # });
@@ -207,7 +207,7 @@ pub async fn sign_message<R: Runtime>(
 ///     Principal::from_text("vaupb-eqaaa-aaaai-qplka-cai").unwrap()
 /// );
 /// let (payer, _) = get_pubkey(
-///     &runtime,
+///     &mut runtime,
 ///     None,
 ///     Some(&derivation_path),
 ///     key_id
@@ -216,7 +216,7 @@ pub async fn sign_message<R: Runtime>(
 /// .unwrap();
 ///
 /// let (pubkey, _) = get_pubkey(
-///     &runtime,
+///     &mut runtime,
 ///     Some(canister_id),
 ///     Some(&derivation_path),
 ///     key_id
@@ -230,7 +230,7 @@ pub async fn sign_message<R: Runtime>(
 /// # }
 /// ```
 pub async fn get_pubkey<R: Runtime>(
-    runtime: &R,
+    runtime: &mut R,
     canister_id: Option<Principal>,
     derivation_path: Option<&DerivationPath>,
     key_id: Ed25519KeyId,

--- a/libs/client/src/fixtures/mod.rs
+++ b/libs/client/src/fixtures/mod.rs
@@ -71,7 +71,7 @@ impl MockRuntime {
 #[async_trait]
 impl Runtime for MockRuntime {
     async fn update_call<In, Out>(
-        &self,
+        &mut self,
         _id: Principal,
         _method: &str,
         _args: In,
@@ -87,7 +87,7 @@ impl Runtime for MockRuntime {
     }
 
     async fn query_call<In, Out>(
-        &self,
+        &mut self,
         _id: Principal,
         _method: &str,
         _args: In,


### PR DESCRIPTION
(XC-317) Change the `Runtime` `query_call` and `update_call` methods to take a `&mut self` argument instead of a `&self`.