### PR TITLE
fix: change `nat16` to `nat32` in examples

### DIFF
--- a/canister/scripts/examples.sh
+++ b/canister/scripts/examples.sh
@@ -170,7 +170,7 @@ GET_SIGNATURES_FOR_ADDRESS_PARAMS="(
     pubkey = \"EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v\";
     commitment = null;
     minContextSlot = null;
-    limit = opt (10 : nat16);
+    limit = opt (10 : nat32);
     before = opt \"${FIRST_SIGNATURE}\";
     until = null;
   },


### PR DESCRIPTION
In the example call to `getSignaturesForAddress` in `examples.sh`, the `limit` request parameter was incorrectly set to an `opt nat16` whereas it should have been an `opt nat32`. This led to a Candid error when running the end-to-end tests and thus the `getSignaturesForAddress` endpoint was not being correctly tested.