### PR TITLE
chore: use build script for `basic_solana` deployment

### DIFF
--- a/examples/basic_solana/build.sh
+++ b/examples/basic_solana/build.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TARGET="wasm32-unknown-unknown"
+
+# Optional manifest path
+MANIFEST_ARG=""
+if [ $# -ge 1 ]; then
+  MANIFEST_ARG="--manifest-path $1"
+fi
+
+# Build based on the platform
+if [ "$(uname)" == "Darwin" ]; then
+  LLVM_PATH=$(brew --prefix llvm)
+  AR="${LLVM_PATH}/bin/llvm-ar" CC="${LLVM_PATH}/bin/clang" cargo build --target "$TARGET" --release $MANIFEST_ARG
+else
+  cargo build --target "$TARGET" --release $MANIFEST_ARG
+fi

--- a/examples/basic_solana/local/dfx.json
+++ b/examples/basic_solana/local/dfx.json
@@ -5,9 +5,7 @@
       "candid": "../../../canister/sol_rpc_canister.did",
       "package": "sol_rpc_canister",
       "type": "custom",
-      "build": [
-        "cargo build --no-default-features --target wasm32-unknown-unknown --release --manifest-path ../../../canister/Cargo.toml"
-      ],
+      "build": "../build.sh \"../../../canister/Cargo.toml\"",
       "wasm": "../../../target/wasm32-unknown-unknown/release/sol_rpc_canister.wasm",
       "metadata": [
         {
@@ -21,9 +19,7 @@
       "candid": "../basic_solana.did",
       "package": "basic_solana",
       "type": "custom",
-      "build": [
-        "cargo build --no-default-features --target wasm32-unknown-unknown --release"
-      ],
+      "build": "../build.sh",
       "wasm": "../../../target/wasm32-unknown-unknown/release/basic_solana.wasm",
       "metadata": [
         {

--- a/examples/basic_solana/mainnet/dfx.json
+++ b/examples/basic_solana/mainnet/dfx.json
@@ -4,9 +4,7 @@
       "candid": "../basic_solana.did",
       "package": "basic_solana",
       "type": "custom",
-      "build": [
-        "cargo build --no-default-features --target wasm32-unknown-unknown --release"
-      ],
+      "build": "../build.sh",
       "wasm": "../../../target/wasm32-unknown-unknown/release/basic_solana.wasm",
       "metadata": [
         {


### PR DESCRIPTION
Use a build script to deploy `basic_solana` locally and on Mainnet which checks what platform it is running to ensure proper handling of `llvm`.