### PR TITLE
docs: a notes in READMEs about `llvm` on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ More examples are available [here](canister/scripts/examples.sh).
 #### Prerequisites:
 
 * Add the `sol_rpc_client` library as a dependency in your `Cargo.toml`.
+* On macOS, an `llvm` version that supports the `wasm32-unknown-unknown` target is required. This is because the Rust [`ztsd`](https://docs.rs/zstd/latest/zstd/) library (used for example to parse the result of the Solana [`getAccountInfo`](https://solana.com/de/docs/rpc/http/getaccountinfo) JSON-RPC method with `base64+zstd` encoding) requires `llvm` to build. The default `llvm` version provided by XCode does not meet this requirement. Instead, install the [Homebrew version](https://formulae.brew.sh/formula/llvm), using `brew install llvm`.
 
 #### Example with [`getSlot`](https://solana.com/de/docs/rpc/http/getslot)
 

--- a/examples/basic_solana/README.md
+++ b/examples/basic_solana/README.md
@@ -25,10 +25,8 @@ the [chain fusion overview](https://internetcomputer.org/docs/building-apps/chai
 ## Prerequisites
 
 * [ ] Install the [IC SDK](https://internetcomputer.org/docs/current/developer-docs/setup/install/index.mdx) v0.27.0. If the IC SDK is already installed with an old version, install 0.27.0 with [`dfxvm`](https://internetcomputer.org/docs/building-apps/developer-tools/dev-tools-overview#dfxvm).
-* [ ] Confirm the IC SDK has been installed with the correct version:
-```shell
-dfx --version
-```
+* [ ] Confirm the IC SDK has been installed with the correct version with `dfx --version`.
+* [ ] On macOS, an `llvm` version that supports the `wasm32-unknown-unknown` target is required. This is because the Rust [`ztsd`](https://docs.rs/zstd/latest/zstd/) library (used for example to parse the result of the Solana [`getAccountInfo`](https://solana.com/de/docs/rpc/http/getaccountinfo) JSON-RPC method with `base64+zstd` encoding) requires `llvm` to build. The default `llvm` version provided by XCode does not meet this requirement. Instead, install the [Homebrew version](https://formulae.brew.sh/formula/llvm), using `brew install llvm`.
 
 ## Step 1: Building and deploying sample code
 
@@ -41,9 +39,6 @@ git clone https://github.com/dfinity/sol-rpc-canister
 cd examples/basic_solana
 git submodule update --init --recursive
 ```
-
-**If you are using macOS, you'll need to install Homebrew and run `brew install llvm` to be able to
-compile the example.**
 
 ### Acquire cycles to deploy
 


### PR DESCRIPTION
Add a note in the top-level README about `llvm` on macOS and expand the already-existing note in the `basic_solana` README. Both notes are identical and explain why a specific `llvm` version is required, and how to install it (i.e. with `brew`).