### PR TITLE
fix: use correct fee for t-sig with local development key

### DIFF
--- a/libs/client/src/ed25519.rs
+++ b/libs/client/src/ed25519.rs
@@ -182,7 +182,7 @@ pub async fn sign_message<R: Runtime>(
             (arg,),
             match key_id {
                 Ed25519KeyId::MainnetTestKey1 => SIGN_WITH_SCHNORR_TEST_FEE,
-                // Threshold signatures are charged the same in local development environments as in prod, see 
+                // Threshold signatures are charged the same in local development environments as in prod, see
                 // https://internetcomputer.org/docs/references/t-sigs-how-it-works#local-development-environment
                 Ed25519KeyId::LocalDevelopment | Ed25519KeyId::MainnetProdKey1 => {
                     SIGN_WITH_SCHNORR_PRODUCTION_FEE

--- a/libs/client/src/ed25519.rs
+++ b/libs/client/src/ed25519.rs
@@ -181,10 +181,12 @@ pub async fn sign_message<R: Runtime>(
             "sign_with_schnorr",
             (arg,),
             match key_id {
-                Ed25519KeyId::LocalDevelopment | Ed25519KeyId::MainnetTestKey1 => {
-                    SIGN_WITH_SCHNORR_TEST_FEE
+                Ed25519KeyId::MainnetTestKey1 => SIGN_WITH_SCHNORR_TEST_FEE,
+                // Threshold signatures are charged the same in local development environments as in prod, see 
+                // https://internetcomputer.org/docs/references/t-sigs-how-it-works#local-development-environment
+                Ed25519KeyId::LocalDevelopment | Ed25519KeyId::MainnetProdKey1 => {
+                    SIGN_WITH_SCHNORR_PRODUCTION_FEE
                 }
-                Ed25519KeyId::MainnetProdKey1 => SIGN_WITH_SCHNORR_PRODUCTION_FEE,
             },
         )
         .await?;


### PR DESCRIPTION
(XC-403) Until now, calls to the `sign_with_schnorr` management canister endpoint were incorrectly using the same fee for local and test keys, whereas the local key requires the same fee as the production key, see [the documentation](https://internetcomputer.org/docs/references/t-sigs-how-it-works#local-development-environment).