### PR TITLE
chore: bump `sol_rpc_client` to `v1.0.1`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4470,7 +4470,7 @@ dependencies = [
 
 [[package]]
 name = "sol_rpc_client"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "assert_matches",
  "async-trait",

--- a/libs/client/Cargo.toml
+++ b/libs/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sol_rpc_client"
-version = "1.0.0"
+version = "1.0.1"
 description = "Client to interact with the SOL RPC canister"
 authors.workspace = true
 edition.workspace = true


### PR DESCRIPTION
Bump the `sol_rpc_client` crate to `v1.0.1`.