### PR TITLE
docs: add build requirements to READMEs and rustdoc 

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,31 @@ More examples are available [here](canister/scripts/examples.sh).
 
 #### Prerequisites:
 
-* Add the `sol_rpc_client` library as a dependency in your `Cargo.toml`.
+* Add the `sol_rpc_client` library as a dependency in your `Cargo.toml`. 
+* Copy the `[patch.crates-io]` section from the top-level [`Cargo.toml`](https://github.com/dfinity/sol-rpc-canister/blob/main/Cargo.toml) file in the [`dfinity/sol-rpc`](https://github.com/dfinity/sol-rpc-canister/) repository into your own `Cargo.toml`. This is necessary because the Solana SDK’s `wasm32-unknown-unknown` target assumes a browser environment and depends on `wasm-bindgen`, which is incompatible with canister environments. See [this issue](https://github.com/anza-xyz/solana-sdk/issues/117) for details.
+* Add the following to your `Cargo.toml` file:
+  ```toml
+  getrandom = { version = "*", default-features = false, features = ["custom"] }
+  ```
+  This ensures that the `getrandom` crate (a transitive dependency of the Solana SDK) does not enable the `js` feature, which also assumes a browser environment and pulls in `wasm-bindgen`.
+  > 💡 You can also use a specific version of `getrandom`, as long as the `default-features = false` and `features = ["custom"]` flags are set.
+  
+  For more information, see [this blog post](https://forum.dfinity.org/t/module-imports-function-wbindgen-describe-from-wbindgen-placeholder-that-is-not-exported-by-the-runtime/11545/6).
+* On **macOS**, an `llvm` version that supports the `wasm32-unknown-unknown` target is required. This is because the `zstd` crate (used, for example, to decode `base64+zstd`-encoded responses from Solana's [`getAccountInfo`](https://solana.com/de/docs/rpc/http/getaccountinfo)) depends on LLVM during compilation. The default LLVM bundled with Xcode does not support `wasm32-unknown-unknown`. To fix this:
+  * Install the [Homebrew version](https://formulae.brew.sh/formula/llvm) of LLVM:
+  ```sh
+  brew install llvm
+  ```
+  * Create a top-level `.cargo/config.toml` file in your project (or modify the existing one) and add the following entries:
+   ```toml
+  [env]
+  AR="<LLVM_PATH>/bin/llvm-ar"
+  CC="<LLVM_PATH>/bin/clang"
+  ```
+  Where you need to replace `<LLVM_PATH>` with the output of the following command:
+  ```sh
+  brew --prefix llvm
+  ```
 
 #### Example with [`getSlot`](https://solana.com/de/docs/rpc/http/getslot)
 

--- a/README.md
+++ b/README.md
@@ -75,10 +75,11 @@ More examples are available [here](canister/scripts/examples.sh).
 * Copy the `[patch.crates-io]` section from the top-level [`Cargo.toml`](https://github.com/dfinity/sol-rpc-canister/blob/main/Cargo.toml) file in the [`dfinity/sol-rpc`](https://github.com/dfinity/sol-rpc-canister/) repository into your own `Cargo.toml`. This is necessary because the Solana SDK’s `wasm32-unknown-unknown` target assumes a browser environment and depends on `wasm-bindgen`, which is incompatible with canister environments. See [this issue](https://github.com/anza-xyz/solana-sdk/issues/117) for details.
 * Add the following to your `Cargo.toml` file:
   ```toml
-  getrandom = { version = "*", default-features = false, features = ["custom"] }
+  getrandom = { version = "*", features = ["custom"] }
   ```
-  This ensures that the `getrandom` crate (a transitive dependency of the Solana SDK) does not enable the `js` feature, which also assumes a browser environment and pulls in `wasm-bindgen`.
-  > 💡 You can also use a specific version of `getrandom`, as long as the `default-features = false` and `features = ["custom"]` flags are set.
+  This ensures that the `getrandom` crate (a transitive dependency of the Solana SDK) does not pull in `wasm-bindgen`, which is incompatible with canister environments.
+  > 💡 You can also specify an exact version of `getrandom`, as long as the `custom` feature is enabled:
+  `getrandom = { version = "0.2.14", features = ["custom"] }`.
   
   For more information, see [this blog post](https://forum.dfinity.org/t/module-imports-function-wbindgen-describe-from-wbindgen-placeholder-that-is-not-exported-by-the-runtime/11545/6).
 * On **macOS**, an `llvm` version that supports the `wasm32-unknown-unknown` target is required. This is because the `zstd` crate (used, for example, to decode `base64+zstd`-encoded responses from Solana's [`getAccountInfo`](https://solana.com/de/docs/rpc/http/getaccountinfo)) depends on LLVM during compilation. The default LLVM bundled with Xcode does not support `wasm32-unknown-unknown`. To fix this:

--- a/README.md
+++ b/README.md
@@ -71,32 +71,8 @@ More examples are available [here](canister/scripts/examples.sh).
 
 #### Prerequisites:
 
-* Add the `sol_rpc_client` library as a dependency in your `Cargo.toml`. 
-* Copy the `[patch.crates-io]` section from the top-level [`Cargo.toml`](https://github.com/dfinity/sol-rpc-canister/blob/main/Cargo.toml) file in the [`dfinity/sol-rpc`](https://github.com/dfinity/sol-rpc-canister/) repository into your own `Cargo.toml`. This is necessary because the Solana SDK’s `wasm32-unknown-unknown` target assumes a browser environment and depends on `wasm-bindgen`, which is incompatible with canister environments. See [this issue](https://github.com/anza-xyz/solana-sdk/issues/117) for details.
-* Add the following to your `Cargo.toml` file:
-  ```toml
-  getrandom = { version = "*", features = ["custom"] }
-  ```
-  This ensures that the `getrandom` crate (a transitive dependency of the Solana SDK) does not pull in `wasm-bindgen`, which is incompatible with canister environments.
-  > 💡 You can also specify an exact version of `getrandom`, as long as the `custom` feature is enabled:
-  `getrandom = { version = "0.2.14", features = ["custom"] }`.
-  
-  For more information, see [this blog post](https://forum.dfinity.org/t/module-imports-function-wbindgen-describe-from-wbindgen-placeholder-that-is-not-exported-by-the-runtime/11545/6).
-* On **macOS**, an `llvm` version that supports the `wasm32-unknown-unknown` target is required. This is because the `zstd` crate (used, for example, to decode `base64+zstd`-encoded responses from Solana's [`getAccountInfo`](https://solana.com/de/docs/rpc/http/getaccountinfo)) depends on LLVM during compilation. The default LLVM bundled with Xcode does not support `wasm32-unknown-unknown`. To fix this:
-  * Install the [Homebrew version](https://formulae.brew.sh/formula/llvm) of LLVM:
-  ```sh
-  brew install llvm
-  ```
-  * Create a top-level `.cargo/config.toml` file in your project (or modify the existing one) and add the following entries:
-   ```toml
-  [env]
-  AR="<LLVM_PATH>/bin/llvm-ar"
-  CC="<LLVM_PATH>/bin/clang"
-  ```
-  Where you need to replace `<LLVM_PATH>` with the output of the following command:
-  ```sh
-  brew --prefix llvm
-  ```
+* Add the `sol_rpc_client` library as a dependency in your `Cargo.toml`.
+* Follow the steps outlined [here](https://github.com/dfinity/sol-rpc-canister/blob/main/libs/client/README.md#build-requirements) to ensure your code compiles.
 
 #### Example with [`getSlot`](https://solana.com/de/docs/rpc/http/getslot)
 

--- a/examples/basic_solana/README.md
+++ b/examples/basic_solana/README.md
@@ -28,7 +28,7 @@ the [chain fusion overview](https://internetcomputer.org/docs/building-apps/chai
 * [ ] Confirm the IC SDK has been installed with the correct version with `dfx --version`.
 * [ ] On **macOS**, an `llvm` version that supports the `wasm32-unknown-unknown` target is required. This is because the `zstd` crate (used, for example, to decode `base64+zstd`-encoded responses from Solana's [`getAccountInfo`](https://solana.com/de/docs/rpc/http/getaccountinfo)) depends on LLVM during compilation. The default LLVM bundled with Xcode does not support `wasm32-unknown-unknown`. To fix this, install the [Homebrew version](https://formulae.brew.sh/formula/llvm), using `brew install llvm`.
 
-> ⚠️ **NOTE:** If you wish to use this example as a starting point for your own project, make sure your refer to the [prerequisites section](https://github.com/dfinity/sol-rpc-canister?tab=readme-ov-file#from-within-a-rust-canister) in the top-level README.
+> ⚠️ **NOTE:** If you wish to use this example as a starting point for your own project, make sure your follow the instructions in the [build requirements](https://github.com/dfinity/sol-rpc-canister/blob/main/libs/client/README.md#build-requirements) for the `sol_rpc_client` crate to ensure that your code compiles.
 
 ## Step 1: Building and deploying sample code
 

--- a/examples/basic_solana/README.md
+++ b/examples/basic_solana/README.md
@@ -25,10 +25,8 @@ the [chain fusion overview](https://internetcomputer.org/docs/building-apps/chai
 ## Prerequisites
 
 * [ ] Install the [IC SDK](https://internetcomputer.org/docs/current/developer-docs/setup/install/index.mdx) v0.27.0. If the IC SDK is already installed with an old version, install 0.27.0 with [`dfxvm`](https://internetcomputer.org/docs/building-apps/developer-tools/dev-tools-overview#dfxvm).
-* [ ] Confirm the IC SDK has been installed with the correct version:
-```shell
-dfx --version
-```
+* [ ] Confirm the IC SDK has been installed with the correct version with `dfx --version`.
+* [ ] On **macOS**, an `llvm` version that supports the `wasm32-unknown-unknown` target is required. This is because the Rust [`ztsd`](https://docs.rs/zstd/latest/zstd/) library (used for example to parse the result of the Solana [`getAccountInfo`](https://solana.com/de/docs/rpc/http/getaccountinfo) JSON-RPC method with `base64+zstd` encoding) requires `llvm` to build. The default `llvm` version provided by XCode does not meet this requirement. Instead, install the [Homebrew version](https://formulae.brew.sh/formula/llvm), using `brew install llvm`.
 
 ## Step 1: Building and deploying sample code
 

--- a/examples/basic_solana/README.md
+++ b/examples/basic_solana/README.md
@@ -26,7 +26,9 @@ the [chain fusion overview](https://internetcomputer.org/docs/building-apps/chai
 
 * [ ] Install the [IC SDK](https://internetcomputer.org/docs/current/developer-docs/setup/install/index.mdx) v0.27.0. If the IC SDK is already installed with an old version, install 0.27.0 with [`dfxvm`](https://internetcomputer.org/docs/building-apps/developer-tools/dev-tools-overview#dfxvm).
 * [ ] Confirm the IC SDK has been installed with the correct version with `dfx --version`.
-* [ ] On **macOS**, an `llvm` version that supports the `wasm32-unknown-unknown` target is required. This is because the Rust [`ztsd`](https://docs.rs/zstd/latest/zstd/) library (used for example to parse the result of the Solana [`getAccountInfo`](https://solana.com/de/docs/rpc/http/getaccountinfo) JSON-RPC method with `base64+zstd` encoding) requires `llvm` to build. The default `llvm` version provided by XCode does not meet this requirement. Instead, install the [Homebrew version](https://formulae.brew.sh/formula/llvm), using `brew install llvm`.
+* [ ] On **macOS**, an `llvm` version that supports the `wasm32-unknown-unknown` target is required. This is because the `zstd` crate (used, for example, to decode `base64+zstd`-encoded responses from Solana's [`getAccountInfo`](https://solana.com/de/docs/rpc/http/getaccountinfo)) depends on LLVM during compilation. The default LLVM bundled with Xcode does not support `wasm32-unknown-unknown`. To fix this, install the [Homebrew version](https://formulae.brew.sh/formula/llvm), using `brew install llvm`.
+
+> ⚠️ **NOTE:** If you wish to use this example as a starting point for your own project, make sure your refer to the [prerequisites section](https://github.com/dfinity/sol-rpc-canister?tab=readme-ov-file#from-within-a-rust-canister) in the top-level README.
 
 ## Step 1: Building and deploying sample code
 

--- a/libs/client/README.md
+++ b/libs/client/README.md
@@ -7,3 +7,24 @@
 Library to interact with the [SOL RPC canister](https://github.com/dfinity/sol-rpc-canister/) from a canister running on
 the Internet Computer.
 See the Rust [documentation](https://docs.rs/sol_rpc_client) for more details.
+
+> ⚠️ **Build Requirements:**
+>
+> 1. To build this crate, you must copy the `[patch.crates-io]` section from the top-level [`Cargo.toml`](https://github.com/dfinity/sol-rpc-canister/blob/main/Cargo.toml) file in the [`dfinity/sol-rpc`](https://github.com/dfinity/sol-rpc-canister/) repository into your own `Cargo.toml`.  
+> This is necessary because the Solana SDK’s `wasm32-unknown-unknown` target assumes a browser environment and depends on `wasm-bindgen`, which is incompatible with use inside a canister.  
+> See [this issue](https://github.com/anza-xyz/solana-sdk/issues/117) for details.
+>
+> 2. On **macOS**, you need an LLVM version that supports the `wasm32-unknown-unknown` target because the Rust [`zstd`](https://docs.rs/zstd/latest/zstd/) crate (used, e.g., to decode `base64+zstd` responses from Solana’s [`getAccountInfo`](https://solana.com/de/docs/rpc/http/getaccountinfo) JSON-RPC method) relies on LLVM during compilation. The default LLVM from Xcode is incompatible. To fix this:
+>   * Install LLVM via Homebrew:
+>     ```sh
+>     brew install llvm
+>     ```
+>   * Add this to your `.cargo/config.toml`:
+>     ```toml
+>     [target.'cfg(target_os = "macos")'.env]
+>     LLVM_SYS_130_PREFIX = "/opt/homebrew/opt/llvm"
+>     ```
+>     > 💡 You can find the correct path with:
+>     >    ```sh
+>     >    brew --prefix llvm
+>     >    ```

--- a/libs/client/README.md
+++ b/libs/client/README.md
@@ -8,31 +8,37 @@ Library to interact with the [SOL RPC canister](https://github.com/dfinity/sol-r
 the Internet Computer.
 See the Rust [documentation](https://docs.rs/sol_rpc_client) for more details.
 
-> ⚠️ **Build Requirements:**
-> 
-> If you are using the `sol_rpc_types` crate inside a canister, make sure to follow these steps to ensure your code compiles:
->
-> 1. Copy the `[patch.crates-io]` section from the top-level [`Cargo.toml`](https://github.com/dfinity/sol-rpc-canister/blob/main/Cargo.toml) file in the [`dfinity/sol-rpc`](https://github.com/dfinity/sol-rpc-canister/) repository into your own `Cargo.toml`. This is necessary because the Solana SDK’s `wasm32-unknown-unknown` target assumes a browser environment and depends on `wasm-bindgen`, which is incompatible with canister environments. See [this issue](https://github.com/anza-xyz/solana-sdk/issues/117) for details.
-> 2. Add the following to your `Cargo.toml` file:
->   ```toml
->   getrandom = { version = "*", default-features = false, features = ["custom"] }
->   ```
->   This ensures that the `getrandom` crate (a transitive dependency of the Solana SDK) does not enable the `js` feature, which also assumes a browser environment and pulls in `wasm-bindgen`. 
->      > 💡 You can also use a specific version of `getrandom`, as long as the `default-features = false` and `features = ["custom"]` flags are set.
-> 
->   For more information, see [this blog post](https://forum.dfinity.org/t/module-imports-function-wbindgen-describe-from-wbindgen-placeholder-that-is-not-exported-by-the-runtime/11545/6).
-> 3. On **macOS**, an `llvm` version that supports the `wasm32-unknown-unknown` target is required. This is because the `zstd` crate (used, for example, to decode `base64+zstd`-encoded responses from Solana's [`getAccountInfo`](https://solana.com/de/docs/rpc/http/getaccountinfo)) depends on LLVM during compilation. The default LLVM bundled with Xcode does not support `wasm32-unknown-unknown`. To fix this:
->   * Install the [Homebrew version](https://formulae.brew.sh/formula/llvm) of LLVM:
->     ```sh
->     brew install llvm
->     ```
->   * Create a top-level `.cargo/config.toml` file in your project (or modify the existing one) and add the following entries:
->     ```toml
->     [env]
->     AR="<LLVM_PATH>/bin/llvm-ar"
->     CC="<LLVM_PATH>/bin/clang"
->     ```
->     Where you need to replace `<LLVM_PATH>` with the output of the following command:
->     ```sh
->     brew --prefix llvm
->     ```
+## Build Requirements
+
+If you are using the `sol_rpc_types` crate inside a canister, make sure to follow these steps to ensure your code compiles:
+
+1. **Add patch overrides**  
+   Copy the `[patch.crates-io]` section from the top-level [`Cargo.toml`](https://github.com/dfinity/sol-rpc-canister/blob/main/Cargo.toml) file in the [`dfinity/sol-rpc`](https://github.com/dfinity/sol-rpc-canister/) repository into your own `Cargo.toml`.  
+   This is necessary because the Solana SDK’s `wasm32-unknown-unknown` target assumes a browser environment and depends on `wasm-bindgen`, which is incompatible with canister environments.  
+   See [this issue](https://github.com/anza-xyz/solana-sdk/issues/117) for more details.
+
+2. **Override `getrandom` features**  
+   Add the following to your `Cargo.toml` file:
+   ```toml
+   getrandom = { version = "*", features = ["custom"] }
+   ```
+   This ensures that the `getrandom` crate (a transitive dependency of the Solana SDK) does not pull in `wasm-bindgen`, which is incompatible with canister environments.
+   > 💡 You can also specify an exact version of `getrandom`, as long as the `custom` feature is enabled, e.g. `getrandom = { version = "0.2.14", features = ["custom"] }`.
+
+   For more information, see [this blog post](https://forum.dfinity.org/t/module-imports-function-wbindgen-describe-from-wbindgen-placeholder-that-is-not-exported-by-the-runtime/11545/6).
+3. **macOS-specific LLVM setup**  
+   On **macOS**, an `llvm` version that supports the `wasm32-unknown-unknown` target is required. This is because the `zstd` crate (used, for example, to decode `base64+zstd`-encoded responses from Solana's [`getAccountInfo`](https://solana.com/de/docs/rpc/http/getaccountinfo)) depends on LLVM during compilation. The default LLVM bundled with Xcode does not support `wasm32-unknown-unknown`. To fix this:
+   * Install the [Homebrew version](https://formulae.brew.sh/formula/llvm) of LLVM:
+     ```sh
+     brew install llvm
+     ```
+   * Create a top-level `.cargo/config.toml` file in your project (or modify the existing one) and add the following entries:
+      ```toml
+      [env]
+      AR="<LLVM_PATH>/bin/llvm-ar"
+      CC="<LLVM_PATH>/bin/clang"
+      ```
+      Where you need to replace `<LLVM_PATH>` with the output of the following command:
+      ```sh
+      brew --prefix llvm
+      ```

--- a/libs/client/README.md
+++ b/libs/client/README.md
@@ -9,22 +9,30 @@ the Internet Computer.
 See the Rust [documentation](https://docs.rs/sol_rpc_client) for more details.
 
 > ⚠️ **Build Requirements:**
+> 
+> If you are using the `sol_rpc_types` crate inside a canister, make sure to follow these steps to ensure your code compiles:
 >
-> 1. To build this crate, you must copy the `[patch.crates-io]` section from the top-level [`Cargo.toml`](https://github.com/dfinity/sol-rpc-canister/blob/main/Cargo.toml) file in the [`dfinity/sol-rpc`](https://github.com/dfinity/sol-rpc-canister/) repository into your own `Cargo.toml`.  
-> This is necessary because the Solana SDK’s `wasm32-unknown-unknown` target assumes a browser environment and depends on `wasm-bindgen`, which is incompatible with use inside a canister.  
-> See [this issue](https://github.com/anza-xyz/solana-sdk/issues/117) for details.
->
-> 2. On **macOS**, you need an LLVM version that supports the `wasm32-unknown-unknown` target because the Rust [`zstd`](https://docs.rs/zstd/latest/zstd/) crate (used, e.g., to decode `base64+zstd` responses from Solana’s [`getAccountInfo`](https://solana.com/de/docs/rpc/http/getaccountinfo) JSON-RPC method) relies on LLVM during compilation. The default LLVM from Xcode is incompatible. To fix this:
->   * Install LLVM via Homebrew:
+> 1. Copy the `[patch.crates-io]` section from the top-level [`Cargo.toml`](https://github.com/dfinity/sol-rpc-canister/blob/main/Cargo.toml) file in the [`dfinity/sol-rpc`](https://github.com/dfinity/sol-rpc-canister/) repository into your own `Cargo.toml`. This is necessary because the Solana SDK’s `wasm32-unknown-unknown` target assumes a browser environment and depends on `wasm-bindgen`, which is incompatible with canister environments. See [this issue](https://github.com/anza-xyz/solana-sdk/issues/117) for details.
+> 2. Add the following to your `Cargo.toml` file:
+>   ```toml
+>   getrandom = { version = "*", default-features = false, features = ["custom"] }
+>   ```
+>   This ensures that the `getrandom` crate (a transitive dependency of the Solana SDK) does not enable the `js` feature, which also assumes a browser environment and pulls in `wasm-bindgen`. 
+>      > 💡 You can also use a specific version of `getrandom`, as long as the `default-features = false` and `features = ["custom"]` flags are set.
+> 
+>   For more information, see [this blog post](https://forum.dfinity.org/t/module-imports-function-wbindgen-describe-from-wbindgen-placeholder-that-is-not-exported-by-the-runtime/11545/6).
+> 3. On **macOS**, an `llvm` version that supports the `wasm32-unknown-unknown` target is required. This is because the `zstd` crate (used, for example, to decode `base64+zstd`-encoded responses from Solana's [`getAccountInfo`](https://solana.com/de/docs/rpc/http/getaccountinfo)) depends on LLVM during compilation. The default LLVM bundled with Xcode does not support `wasm32-unknown-unknown`. To fix this:
+>   * Install the [Homebrew version](https://formulae.brew.sh/formula/llvm) of LLVM:
 >     ```sh
 >     brew install llvm
 >     ```
->   * Add this to your `.cargo/config.toml`:
+>   * Create a top-level `.cargo/config.toml` file in your project (or modify the existing one) and add the following entries:
 >     ```toml
->     [target.'cfg(target_os = "macos")'.env]
->     LLVM_SYS_130_PREFIX = "/opt/homebrew/opt/llvm"
+>     [env]
+>     AR="<LLVM_PATH>/bin/llvm-ar"
+>     CC="<LLVM_PATH>/bin/clang"
 >     ```
->     > 💡 You can find the correct path with:
->     >    ```sh
->     >    brew --prefix llvm
->     >    ```
+>     Where you need to replace `<LLVM_PATH>` with the output of the following command:
+>     ```sh
+>     brew --prefix llvm
+>     ```

--- a/libs/client/src/lib.rs
+++ b/libs/client/src/lib.rs
@@ -113,6 +113,16 @@
 //! # Ok(())
 //! # }
 //! ```
+//!
+//! # Build Notice
+//!
+//! To successfully build this crate, you must copy the `[patch.crates-io]` section from the top-level
+//! [`Cargo.toml`](https://github.com/dfinity/sol-rpc-canister/blob/main/Cargo.toml) file in the
+//! [dfinity/sol-rpc](https://github.com/dfinity/sol-rpc-canister) repository into your own `Cargo.toml`. 
+//! This step is necessary because the Solana SDK’s `wasm32-unknown-unknown` target assumes a browser 
+//! environment and depends on `wasm-bindgen`, which is incompatible with use inside a canister.
+//!
+//! For more information, see [this upstream issue](https://github.com/anza-xyz/solana-sdk/issues/117).
 
 #![forbid(unsafe_code)]
 #![forbid(missing_docs)]

--- a/libs/client/src/lib.rs
+++ b/libs/client/src/lib.rs
@@ -144,7 +144,7 @@
 //!
 //! 3. **macOS-specific setup for `zstd` dependency**
 //!
-//!    On **macOS**, an `llvm` version that supports the `wasm32-unknown-unknown` target is required. 
+//!    On **macOS**, an `llvm` version that supports the `wasm32-unknown-unknown` target is required.
 //!    This is because the  [`zstd`](https://docs.rs/zstd/latest/zstd/) crate (used, for example, to decode
 //!    `base64+zstd`-encoded responses from Solana’s [`getAccountInfo`](https://solana.com/de/docs/rpc/http/getaccountinfo))
 //!    relies on LLVM during compilation.

--- a/libs/client/src/lib.rs
+++ b/libs/client/src/lib.rs
@@ -116,60 +116,9 @@
 //!
 //! ⚠️ **Build Requirements**
 //!
-//! If you are using the `sol_rpc_client` crate inside a canister, make sure to follow these steps to ensure your code compiles:
-//!
-//! 1. **Patch Solana SDK dependencies**
-//!
-//!    Copy the `[patch.crates-io]` section from the top-level [`Cargo.toml`](https://github.com/dfinity/sol-rpc-canister/blob/main/Cargo.toml)
-//!    file in the [`dfinity/sol-rpc`](https://github.com/dfinity/sol-rpc-canister/) repository into your own `Cargo.toml`.
-//!
-//!    This is necessary because the Solana SDK’s `wasm32-unknown-unknown` target assumes a browser environment and depends on
-//!    `wasm-bindgen`, which is incompatible with use inside a canister.  
-//!    See [this issue](https://github.com/anza-xyz/solana-sdk/issues/117) for more information.
-//!
-//! 2. **Configure the `getrandom` crate**
-//!
-//!    Add the following entry to your `Cargo.toml` file:
-//!
-//!    ```toml
-//!    getrandom = { version = "*", default-features = false, features = ["custom"] }
-//!    ```
-//!
-//!    This prevents the `js` feature of `getrandom` (a transitive dependency of the Solana SDK) from being enabled.  
-//!    The `js` feature assumes a browser environment and depends on `wasm-bindgen`, which is incompatible with canisters.
-//!
-//!    💡 You can also specify a particular version for `getrandom`, as long as the `default-features = false` and `features = ["custom"]` flags are set.
-//!
-//!    See [this forum post](https://forum.dfinity.org/t/module-imports-function-wbindgen-describe-from-wbindgen-placeholder-that-is-not-exported-by-the-runtime/11545/6) for more details.
-//!
-//! 3. **macOS-specific setup for `zstd` dependency**
-//!
-//!    On **macOS**, an `llvm` version that supports the `wasm32-unknown-unknown` target is required.
-//!    This is because the  [`zstd`](https://docs.rs/zstd/latest/zstd/) crate (used, for example, to decode
-//!    `base64+zstd`-encoded responses from Solana’s [`getAccountInfo`](https://solana.com/de/docs/rpc/http/getaccountinfo))
-//!    relies on LLVM during compilation.
-//!
-//!    The default LLVM bundled with Xcode does not support `wasm32-unknown-unknown`. To fix this:
-//!
-//!    - Install the [Homebrew version](https://formulae.brew.sh/formula/llvm) of LLVM:
-//!
-//!      ```sh
-//!      brew install llvm
-//!      ```
-//!
-//!    - Create (or modify) your top-level `.cargo/config.toml` and add:
-//!
-//!      ```toml
-//!      [env]
-//!      AR = "<LLVM_PATH>/bin/llvm-ar"
-//!      CC = "<LLVM_PATH>/bin/clang"
-//!      ```
-//!
-//!      Replace `<LLVM_PATH>` with the output of:
-//!
-//!      ```sh
-//!      brew --prefix llvm
-//!      ```
+//! If you are using the `sol_rpc_client` crate inside a canister, make sure to follow the steps
+//! outlined [here](https://github.com/dfinity/sol-rpc-canister/blob/main/libs/client/README.md#build-requirements)
+//! to ensure your code compiles.
 
 #![forbid(unsafe_code)]
 #![forbid(missing_docs)]

--- a/libs/client/src/lib.rs
+++ b/libs/client/src/lib.rs
@@ -114,15 +114,62 @@
 //! # }
 //! ```
 //!
-//! # Build Notice
+//! ⚠️ **Build Requirements**
 //!
-//! To successfully build this crate, you must copy the `[patch.crates-io]` section from the top-level
-//! [`Cargo.toml`](https://github.com/dfinity/sol-rpc-canister/blob/main/Cargo.toml) file in the
-//! [dfinity/sol-rpc](https://github.com/dfinity/sol-rpc-canister) repository into your own `Cargo.toml`. 
-//! This step is necessary because the Solana SDK’s `wasm32-unknown-unknown` target assumes a browser 
-//! environment and depends on `wasm-bindgen`, which is incompatible with use inside a canister.
+//! If you are using the `sol_rpc_client` crate inside a canister, make sure to follow these steps to ensure your code compiles:
 //!
-//! For more information, see [this upstream issue](https://github.com/anza-xyz/solana-sdk/issues/117).
+//! 1. **Patch Solana SDK dependencies**
+//!
+//!    Copy the `[patch.crates-io]` section from the top-level [`Cargo.toml`](https://github.com/dfinity/sol-rpc-canister/blob/main/Cargo.toml)
+//!    file in the [`dfinity/sol-rpc`](https://github.com/dfinity/sol-rpc-canister/) repository into your own `Cargo.toml`.
+//!
+//!    This is necessary because the Solana SDK’s `wasm32-unknown-unknown` target assumes a browser environment and depends on
+//!    `wasm-bindgen`, which is incompatible with use inside a canister.  
+//!    See [this issue](https://github.com/anza-xyz/solana-sdk/issues/117) for more information.
+//!
+//! 2. **Configure the `getrandom` crate**
+//!
+//!    Add the following entry to your `Cargo.toml` file:
+//!
+//!    ```toml
+//!    getrandom = { version = "*", default-features = false, features = ["custom"] }
+//!    ```
+//!
+//!    This prevents the `js` feature of `getrandom` (a transitive dependency of the Solana SDK) from being enabled.  
+//!    The `js` feature assumes a browser environment and depends on `wasm-bindgen`, which is incompatible with canisters.
+//!
+//!    💡 You can also specify a particular version for `getrandom`, as long as the `default-features = false` and `features = ["custom"]` flags are set.
+//!
+//!    See [this forum post](https://forum.dfinity.org/t/module-imports-function-wbindgen-describe-from-wbindgen-placeholder-that-is-not-exported-by-the-runtime/11545/6) for more details.
+//!
+//! 3. **macOS-specific setup for `zstd` dependency**
+//!
+//!    On **macOS**, an `llvm` version that supports the `wasm32-unknown-unknown` target is required. 
+//!    This is because the  [`zstd`](https://docs.rs/zstd/latest/zstd/) crate (used, for example, to decode
+//!    `base64+zstd`-encoded responses from Solana’s [`getAccountInfo`](https://solana.com/de/docs/rpc/http/getaccountinfo))
+//!    relies on LLVM during compilation.
+//!
+//!    The default LLVM bundled with Xcode does not support `wasm32-unknown-unknown`. To fix this:
+//!
+//!    - Install the [Homebrew version](https://formulae.brew.sh/formula/llvm) of LLVM:
+//!
+//!      ```sh
+//!      brew install llvm
+//!      ```
+//!
+//!    - Create (or modify) your top-level `.cargo/config.toml` and add:
+//!
+//!      ```toml
+//!      [env]
+//!      AR = "<LLVM_PATH>/bin/llvm-ar"
+//!      CC = "<LLVM_PATH>/bin/clang"
+//!      ```
+//!
+//!      Replace `<LLVM_PATH>` with the output of:
+//!
+//!      ```sh
+//!      brew --prefix llvm
+//!      ```
 
 #![forbid(unsafe_code)]
 #![forbid(missing_docs)]

--- a/libs/types/README.md
+++ b/libs/types/README.md
@@ -8,22 +8,30 @@ Library defining the types for interacting with the [SOL RPC canister](https://g
 See the Rust [documentation](https://docs.rs/sol_rpc_types) for more details.
 
 > ⚠️ **Build Requirements:**
+> 
+> If you are using the `sol_rpc_client` crate inside a canister, make sure to follow these steps to ensure your code compiles:
 >
-> 1. To build this crate, you must copy the `[patch.crates-io]` section from the top-level [`Cargo.toml`](https://github.com/dfinity/sol-rpc-canister/blob/main/Cargo.toml) file in the [`dfinity/sol-rpc`](https://github.com/dfinity/sol-rpc-canister/) repository into your own `Cargo.toml`.  
-> This is necessary because the Solana SDK’s `wasm32-unknown-unknown` target assumes a browser environment and depends on `wasm-bindgen`, which is incompatible with use inside a canister.  
-> See [this issue](https://github.com/anza-xyz/solana-sdk/issues/117) for details.
->
-> 2. On **macOS**, you need an LLVM version that supports the `wasm32-unknown-unknown` target because the Rust [`zstd`](https://docs.rs/zstd/latest/zstd/) crate (used, e.g., to decode `base64+zstd` responses from Solana’s [`getAccountInfo`](https://solana.com/de/docs/rpc/http/getaccountinfo) JSON-RPC method) relies on LLVM during compilation. The default LLVM from Xcode is incompatible. To fix this:
->   * Install LLVM via Homebrew:
+> 1. Copy the `[patch.crates-io]` section from the top-level [`Cargo.toml`](https://github.com/dfinity/sol-rpc-canister/blob/main/Cargo.toml) file in the [`dfinity/sol-rpc`](https://github.com/dfinity/sol-rpc-canister/) repository into your own `Cargo.toml`. This is necessary because the Solana SDK’s `wasm32-unknown-unknown` target assumes a browser environment and depends on `wasm-bindgen`, which is incompatible with canister environments. See [this issue](https://github.com/anza-xyz/solana-sdk/issues/117) for details.
+> 2. Add the following to your `Cargo.toml` file:
+>   ```toml
+>   getrandom = { version = "*", default-features = false, features = ["custom"] }
+>   ```
+>   This ensures that the `getrandom` crate (a transitive dependency of the Solana SDK) does not enable the `js` feature, which also assumes a browser environment and pulls in `wasm-bindgen`. 
+>      > 💡 You can also use a specific version of `getrandom`, as long as the `default-features = false` and `features = ["custom"]` flags are set.
+> 
+>   For more information, see [this blog post](https://forum.dfinity.org/t/module-imports-function-wbindgen-describe-from-wbindgen-placeholder-that-is-not-exported-by-the-runtime/11545/6).
+> 3. On **macOS**, an `llvm` version that supports the `wasm32-unknown-unknown` target is required. This is because the `zstd` crate (used, for example, to decode `base64+zstd`-encoded responses from Solana's [`getAccountInfo`](https://solana.com/de/docs/rpc/http/getaccountinfo)) depends on LLVM during compilation. The default LLVM bundled with Xcode does not support `wasm32-unknown-unknown`. To fix this:
+>   * Install the [Homebrew version](https://formulae.brew.sh/formula/llvm) of LLVM:
 >     ```sh
 >     brew install llvm
 >     ```
->   * Add this to your `.cargo/config.toml`:
+>   * Create a top-level `.cargo/config.toml` file in your project (or modify the existing one) and add the following entries:
 >     ```toml
->     [target.'cfg(target_os = "macos")'.env]
->     LLVM_SYS_130_PREFIX = "/opt/homebrew/opt/llvm"
+>     [env]
+>     AR="<LLVM_PATH>/bin/llvm-ar"
+>     CC="<LLVM_PATH>/bin/clang"
 >     ```
->     > 💡 You can find the correct path with:
->     >    ```sh
->     >    brew --prefix llvm
->     >    ```
+>     Where you need to replace `<LLVM_PATH>` with the output of the following command:
+>     ```sh
+>     brew --prefix llvm
+>     ```

--- a/libs/types/README.md
+++ b/libs/types/README.md
@@ -6,3 +6,24 @@
 
 Library defining the types for interacting with the [SOL RPC canister](https://github.com/dfinity/sol-rpc-canister/).
 See the Rust [documentation](https://docs.rs/sol_rpc_types) for more details.
+
+> ⚠️ **Build Requirements:**
+>
+> 1. To build this crate, you must copy the `[patch.crates-io]` section from the top-level [`Cargo.toml`](https://github.com/dfinity/sol-rpc-canister/blob/main/Cargo.toml) file in the [`dfinity/sol-rpc`](https://github.com/dfinity/sol-rpc-canister/) repository into your own `Cargo.toml`.  
+> This is necessary because the Solana SDK’s `wasm32-unknown-unknown` target assumes a browser environment and depends on `wasm-bindgen`, which is incompatible with use inside a canister.  
+> See [this issue](https://github.com/anza-xyz/solana-sdk/issues/117) for details.
+>
+> 2. On **macOS**, you need an LLVM version that supports the `wasm32-unknown-unknown` target because the Rust [`zstd`](https://docs.rs/zstd/latest/zstd/) crate (used, e.g., to decode `base64+zstd` responses from Solana’s [`getAccountInfo`](https://solana.com/de/docs/rpc/http/getaccountinfo) JSON-RPC method) relies on LLVM during compilation. The default LLVM from Xcode is incompatible. To fix this:
+>   * Install LLVM via Homebrew:
+>     ```sh
+>     brew install llvm
+>     ```
+>   * Add this to your `.cargo/config.toml`:
+>     ```toml
+>     [target.'cfg(target_os = "macos")'.env]
+>     LLVM_SYS_130_PREFIX = "/opt/homebrew/opt/llvm"
+>     ```
+>     > 💡 You can find the correct path with:
+>     >    ```sh
+>     >    brew --prefix llvm
+>     >    ```

--- a/libs/types/README.md
+++ b/libs/types/README.md
@@ -7,31 +7,6 @@
 Library defining the types for interacting with the [SOL RPC canister](https://github.com/dfinity/sol-rpc-canister/).
 See the Rust [documentation](https://docs.rs/sol_rpc_types) for more details.
 
-> ⚠️ **Build Requirements:**
-> 
-> If you are using the `sol_rpc_types` crate inside a canister, make sure to follow these steps to ensure your code compiles:
->
-> 1. Copy the `[patch.crates-io]` section from the top-level [`Cargo.toml`](https://github.com/dfinity/sol-rpc-canister/blob/main/Cargo.toml) file in the [`dfinity/sol-rpc`](https://github.com/dfinity/sol-rpc-canister/) repository into your own `Cargo.toml`. This is necessary because the Solana SDK’s `wasm32-unknown-unknown` target assumes a browser environment and depends on `wasm-bindgen`, which is incompatible with canister environments. See [this issue](https://github.com/anza-xyz/solana-sdk/issues/117) for details.
-> 2. Add the following to your `Cargo.toml` file:
->   ```toml
->   getrandom = { version = "*", default-features = false, features = ["custom"] }
->   ```
->   This ensures that the `getrandom` crate (a transitive dependency of the Solana SDK) does not enable the `js` feature, which also assumes a browser environment and pulls in `wasm-bindgen`. 
->      > 💡 You can also use a specific version of `getrandom`, as long as the `default-features = false` and `features = ["custom"]` flags are set.
-> 
->   For more information, see [this blog post](https://forum.dfinity.org/t/module-imports-function-wbindgen-describe-from-wbindgen-placeholder-that-is-not-exported-by-the-runtime/11545/6).
-> 3. On **macOS**, an `llvm` version that supports the `wasm32-unknown-unknown` target is required. This is because the `zstd` crate (used, for example, to decode `base64+zstd`-encoded responses from Solana's [`getAccountInfo`](https://solana.com/de/docs/rpc/http/getaccountinfo)) depends on LLVM during compilation. The default LLVM bundled with Xcode does not support `wasm32-unknown-unknown`. To fix this:
->   * Install the [Homebrew version](https://formulae.brew.sh/formula/llvm) of LLVM:
->     ```sh
->     brew install llvm
->     ```
->   * Create a top-level `.cargo/config.toml` file in your project (or modify the existing one) and add the following entries:
->     ```toml
->     [env]
->     AR="<LLVM_PATH>/bin/llvm-ar"
->     CC="<LLVM_PATH>/bin/clang"
->     ```
->     Where you need to replace `<LLVM_PATH>` with the output of the following command:
->     ```sh
->     brew --prefix llvm
->     ```
+## Build Requirements
+
+If you are using the `sol_rpc_types` crate inside a canister, make sure to follow the steps outlined [here](https://github.com/dfinity/sol-rpc-canister/blob/main/libs/client/README.md#build-requirements) to ensure your code compiles.

--- a/libs/types/README.md
+++ b/libs/types/README.md
@@ -9,7 +9,7 @@ See the Rust [documentation](https://docs.rs/sol_rpc_types) for more details.
 
 > ⚠️ **Build Requirements:**
 > 
-> If you are using the `sol_rpc_client` crate inside a canister, make sure to follow these steps to ensure your code compiles:
+> If you are using the `sol_rpc_types` crate inside a canister, make sure to follow these steps to ensure your code compiles:
 >
 > 1. Copy the `[patch.crates-io]` section from the top-level [`Cargo.toml`](https://github.com/dfinity/sol-rpc-canister/blob/main/Cargo.toml) file in the [`dfinity/sol-rpc`](https://github.com/dfinity/sol-rpc-canister/) repository into your own `Cargo.toml`. This is necessary because the Solana SDK’s `wasm32-unknown-unknown` target assumes a browser environment and depends on `wasm-bindgen`, which is incompatible with canister environments. See [this issue](https://github.com/anza-xyz/solana-sdk/issues/117) for details.
 > 2. Add the following to your `Cargo.toml` file:

--- a/libs/types/src/lib.rs
+++ b/libs/types/src/lib.rs
@@ -2,60 +2,9 @@
 //!
 //! ⚠️ **Build Requirements**
 //!
-//! If you are using the `sol_rpc_types` crate inside a canister, make sure to follow these steps to ensure your code compiles:
-//!
-//! 1. **Patch Solana SDK dependencies**
-//!
-//!    Copy the `[patch.crates-io]` section from the top-level [`Cargo.toml`](https://github.com/dfinity/sol-rpc-canister/blob/main/Cargo.toml)
-//!    file in the [`dfinity/sol-rpc`](https://github.com/dfinity/sol-rpc-canister/) repository into your own `Cargo.toml`.
-//!
-//!    This is necessary because the Solana SDK’s `wasm32-unknown-unknown` target assumes a browser environment and depends on
-//!    `wasm-bindgen`, which is incompatible with use inside a canister.
-//!    See [this issue](https://github.com/anza-xyz/solana-sdk/issues/117) for more information.
-//!
-//! 2. **Configure the `getrandom` crate**
-//!
-//!    Add the following entry to your `Cargo.toml` file:
-//!
-//!    ```toml
-//!    getrandom = { version = "*", default-features = false, features = ["custom"] }
-//!    ```
-//!
-//!    This prevents the `js` feature of `getrandom` (a transitive dependency of the Solana SDK) from being enabled.
-//!    The `js` feature assumes a browser environment and depends on `wasm-bindgen`, which is incompatible with canisters.
-//!
-//!    💡 You can also specify a particular version for `getrandom`, as long as the `default-features = false` and `features = ["custom"]` flags are set.
-//!
-//!    See [this forum post](https://forum.dfinity.org/t/module-imports-function-wbindgen-describe-from-wbindgen-placeholder-that-is-not-exported-by-the-runtime/11545/6) for more details.
-//!
-//! 3. **macOS-specific setup for `zstd` dependency**
-//!
-//!    On **macOS**, an `llvm` version that supports the `wasm32-unknown-unknown` target is required.
-//!    This is because the  [`zstd`](https://docs.rs/zstd/latest/zstd/) crate (used, for example, to decode
-//!    `base64+zstd`-encoded responses from Solana’s [`getAccountInfo`](https://solana.com/de/docs/rpc/http/getaccountinfo))
-//!    relies on LLVM during compilation.
-//!
-//!    The default LLVM bundled with Xcode does not support `wasm32-unknown-unknown`. To fix this:
-//!
-//!    - Install the [Homebrew version](https://formulae.brew.sh/formula/llvm) of LLVM:
-//!
-//!      ```sh
-//!      brew install llvm
-//!      ```
-//!
-//!    - Create (or modify) your top-level `.cargo/config.toml` and add:
-//!
-//!      ```toml
-//!      [env]
-//!      AR = "<LLVM_PATH>/bin/llvm-ar"
-//!      CC = "<LLVM_PATH>/bin/clang"
-//!      ```
-//!
-//!      Replace `<LLVM_PATH>` with the output of:
-//!
-//!      ```sh
-//!      brew --prefix llvm
-//!      ```
+//! If you are using the `sol_rpc_types` crate inside a canister, make sure to follow the steps
+//! outlined [here](https://github.com/dfinity/sol-rpc-canister/blob/main/libs/client/README.md#build-requirements)
+//! to ensure your code compiles.
 
 #![forbid(unsafe_code)]
 #![forbid(missing_docs)]

--- a/libs/types/src/lib.rs
+++ b/libs/types/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! ⚠️ **Build Requirements**
 //!
-//! If you are using the `sol_rpc_client` crate inside a canister, make sure to follow these steps to ensure your code compiles:
+//! If you are using the `sol_rpc_types` crate inside a canister, make sure to follow these steps to ensure your code compiles:
 //!
 //! 1. **Patch Solana SDK dependencies**
 //!

--- a/libs/types/src/lib.rs
+++ b/libs/types/src/lib.rs
@@ -1,34 +1,61 @@
 //! Candid types used by the candid interface of the SOL RPC canister.
 //!
-//! # Build Requirements
+//! ⚠️ **Build Requirements**
 //!
-//! 1. To build this crate, you must copy the `[patch.crates-io]` section from the top-level
-//! [`Cargo.toml`](https://github.com/dfinity/sol-rpc-canister/blob/main/Cargo.toml) file in the
-//! [`dfinity/sol-rpc`](https://github.com/dfinity/sol-rpc-canister/) repository into your own `Cargo.toml`.  
-//! This is required because the Solana SDK's `wasm32-unknown-unknown` target assumes a browser environment
-//! and depends on `wasm-bindgen`, which is incompatible with use inside a canister.
+//! If you are using the `sol_rpc_client` crate inside a canister, make sure to follow these steps to ensure your code compiles:
 //!
-//!     See [this upstream issue](https://github.com/anza-xyz/solana-sdk/issues/117) for more info.
+//! 1. **Patch Solana SDK dependencies**
 //!
-//! 2. On **macOS**, an LLVM version supporting the `wasm32-unknown-unknown` target is needed because the Rust
-//! [`zstd`](https://docs.rs/zstd/latest/zstd/) crate (used to decode base64+zstd responses from Solana’s
-//! [`getAccountInfo`](https://solana.com/de/docs/rpc/http/getaccountinfo) JSON-RPC) relies on LLVM during compilation.
-//! The default LLVM from Xcode is incompatible.
+//!    Copy the `[patch.crates-io]` section from the top-level [`Cargo.toml`](https://github.com/dfinity/sol-rpc-canister/blob/main/Cargo.toml)
+//!    file in the [`dfinity/sol-rpc`](https://github.com/dfinity/sol-rpc-canister/) repository into your own `Cargo.toml`.
 //!
-//!     To fix this:
-//!     - Install LLVM via Homebrew:
-//!     ```sh
-//!     brew install llvm
-//!     ```
-//!     - Add the following to your `.cargo/config.toml`:
-//!     ```toml
-//!     [target.'cfg(target_os = "macos")'.env]
-//!     LLVM_SYS_130_PREFIX = "/opt/homebrew/opt/llvm"
-//!     ```
-//!     *Tip:* Find the correct path using:
-//!     ```sh
-//!     brew --prefix llvm
-//!     ```
+//!    This is necessary because the Solana SDK’s `wasm32-unknown-unknown` target assumes a browser environment and depends on
+//!    `wasm-bindgen`, which is incompatible with use inside a canister.  
+//!    See [this issue](https://github.com/anza-xyz/solana-sdk/issues/117) for more information.
+//!
+//! 2. **Configure the `getrandom` crate**
+//!
+//!    Add the following entry to your `Cargo.toml` file:
+//!
+//!    ```toml
+//!    getrandom = { version = "*", default-features = false, features = ["custom"] }
+//!    ```
+//!
+//!    This prevents the `js` feature of `getrandom` (a transitive dependency of the Solana SDK) from being enabled.  
+//!    The `js` feature assumes a browser environment and depends on `wasm-bindgen`, which is incompatible with canisters.
+//!
+//!    💡 You can also specify a particular version for `getrandom`, as long as the `default-features = false` and `features = ["custom"]` flags are set.
+//!
+//!    See [this forum post](https://forum.dfinity.org/t/module-imports-function-wbindgen-describe-from-wbindgen-placeholder-that-is-not-exported-by-the-runtime/11545/6) for more details.
+//!
+//! 3. **macOS-specific setup for `zstd` dependency**
+//!
+//!    On **macOS**, an `llvm` version that supports the `wasm32-unknown-unknown` target is required. 
+//!    This is because the  [`zstd`](https://docs.rs/zstd/latest/zstd/) crate (used, for example, to decode
+//!    `base64+zstd`-encoded responses from Solana’s [`getAccountInfo`](https://solana.com/de/docs/rpc/http/getaccountinfo))
+//!    relies on LLVM during compilation.
+//!
+//!    The default LLVM bundled with Xcode does not support `wasm32-unknown-unknown`. To fix this:
+//!
+//!    - Install the [Homebrew version](https://formulae.brew.sh/formula/llvm) of LLVM:
+//!
+//!      ```sh
+//!      brew install llvm
+//!      ```
+//!
+//!    - Create (or modify) your top-level `.cargo/config.toml` and add:
+//!
+//!      ```toml
+//!      [env]
+//!      AR = "<LLVM_PATH>/bin/llvm-ar"
+//!      CC = "<LLVM_PATH>/bin/clang"
+//!      ```
+//!
+//!      Replace `<LLVM_PATH>` with the output of:
+//!
+//!      ```sh
+//!      brew --prefix llvm
+//!      ```
 
 #![forbid(unsafe_code)]
 #![forbid(missing_docs)]

--- a/libs/types/src/lib.rs
+++ b/libs/types/src/lib.rs
@@ -1,4 +1,34 @@
 //! Candid types used by the candid interface of the SOL RPC canister.
+//!
+//! # Build Requirements
+//!
+//! 1. To build this crate, you must copy the `[patch.crates-io]` section from the top-level
+//! [`Cargo.toml`](https://github.com/dfinity/sol-rpc-canister/blob/main/Cargo.toml) file in the
+//! [`dfinity/sol-rpc`](https://github.com/dfinity/sol-rpc-canister/) repository into your own `Cargo.toml`.  
+//! This is required because the Solana SDK's `wasm32-unknown-unknown` target assumes a browser environment
+//! and depends on `wasm-bindgen`, which is incompatible with use inside a canister.
+//!
+//!     See [this upstream issue](https://github.com/anza-xyz/solana-sdk/issues/117) for more info.
+//!
+//! 2. On **macOS**, an LLVM version supporting the `wasm32-unknown-unknown` target is needed because the Rust
+//! [`zstd`](https://docs.rs/zstd/latest/zstd/) crate (used to decode base64+zstd responses from Solana’s
+//! [`getAccountInfo`](https://solana.com/de/docs/rpc/http/getaccountinfo) JSON-RPC) relies on LLVM during compilation.
+//! The default LLVM from Xcode is incompatible.
+//!
+//!     To fix this:
+//!     - Install LLVM via Homebrew:
+//!     ```sh
+//!     brew install llvm
+//!     ```
+//!     - Add the following to your `.cargo/config.toml`:
+//!     ```toml
+//!     [target.'cfg(target_os = "macos")'.env]
+//!     LLVM_SYS_130_PREFIX = "/opt/homebrew/opt/llvm"
+//!     ```
+//!     *Tip:* Find the correct path using:
+//!     ```sh
+//!     brew --prefix llvm
+//!     ```
 
 #![forbid(unsafe_code)]
 #![forbid(missing_docs)]

--- a/libs/types/src/lib.rs
+++ b/libs/types/src/lib.rs
@@ -10,7 +10,7 @@
 //!    file in the [`dfinity/sol-rpc`](https://github.com/dfinity/sol-rpc-canister/) repository into your own `Cargo.toml`.
 //!
 //!    This is necessary because the Solana SDK’s `wasm32-unknown-unknown` target assumes a browser environment and depends on
-//!    `wasm-bindgen`, which is incompatible with use inside a canister.  
+//!    `wasm-bindgen`, which is incompatible with use inside a canister.
 //!    See [this issue](https://github.com/anza-xyz/solana-sdk/issues/117) for more information.
 //!
 //! 2. **Configure the `getrandom` crate**
@@ -21,7 +21,7 @@
 //!    getrandom = { version = "*", default-features = false, features = ["custom"] }
 //!    ```
 //!
-//!    This prevents the `js` feature of `getrandom` (a transitive dependency of the Solana SDK) from being enabled.  
+//!    This prevents the `js` feature of `getrandom` (a transitive dependency of the Solana SDK) from being enabled.
 //!    The `js` feature assumes a browser environment and depends on `wasm-bindgen`, which is incompatible with canisters.
 //!
 //!    💡 You can also specify a particular version for `getrandom`, as long as the `default-features = false` and `features = ["custom"]` flags are set.
@@ -30,7 +30,7 @@
 //!
 //! 3. **macOS-specific setup for `zstd` dependency**
 //!
-//!    On **macOS**, an `llvm` version that supports the `wasm32-unknown-unknown` target is required. 
+//!    On **macOS**, an `llvm` version that supports the `wasm32-unknown-unknown` target is required.
 //!    This is because the  [`zstd`](https://docs.rs/zstd/latest/zstd/) crate (used, for example, to decode
 //!    `base64+zstd`-encoded responses from Solana’s [`getAccountInfo`](https://solana.com/de/docs/rpc/http/getaccountinfo))
 //!    relies on LLVM during compilation.


### PR DESCRIPTION
(XC-405) Add detailed build requirements to the top-level READMEs as well as the READMEs and rustdocs for the sol_rpc_client` and `sol_rpc_types` crates. These requirements include mentions of:
* patching dependencies with `[path.crates.io]`
* setting appropriate flags for the `getrandom` dependency
* setting up LLVM with `brew` on macOS

Also add a note about the requirements in the `basic_solana` example and update the LLVM instructions there.