### PR TITLE
docs: improve docs for `InstallArgs`

### DIFF
--- a/canister/sol_rpc_canister.did
+++ b/canister/sol_rpc_canister.did
@@ -848,10 +848,20 @@ type Mode = variant {
 
 // The installation args for the Solana RPC canister.
 type InstallArgs = record {
+  // Principals allowed to manage API keys.
+  // If not specified, only controllers may manage API keys.
   manageApiKeys: opt vec principal;
+  // Overrides the RPC providers' default URL and HTTP headers.
+  // If not specified, default URL and HTTP headers are not modified.
   overrideProvider: opt OverrideProvider;
+  // Only log entries matching this filter will be recorded.
+  // If not specified, all log entries are recorded.
   logFilter: opt LogFilter;
+  // Number of subnet nodes.
+  // If not specified, default is 34 (i.e. the number of nodes in the fiduciary subnet).
   numSubnetNodes : opt NumSubnetNodes;
+  // Mode of operation.
+  // If not specified, default is 'Normal'.
   mode : opt Mode;
 };
 

--- a/libs/types/src/lifecycle/mod.rs
+++ b/libs/types/src/lifecycle/mod.rs
@@ -7,18 +7,23 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Default, CandidType, Deserialize)]
 pub struct InstallArgs {
     /// Principals allowed to manage API keys.
+    /// If not specified, only controllers may manage API keys.
     #[serde(rename = "manageApiKeys")]
     pub manage_api_keys: Option<Vec<Principal>>,
     /// Overrides the RPC providers' default URL and HTTP headers.
+    /// If not specified, default URL and HTTP headers are not modified.
     #[serde(rename = "overrideProvider")]
     pub override_provider: Option<OverrideProvider>,
     /// Only log entries matching this filter will be recorded.
+    /// Default is `LogFilter::ShowAll`.
     #[serde(rename = "logFilter")]
     pub log_filter: Option<LogFilter>,
     /// Number of subnet nodes.
+    /// Default is `34` (i.e. the number of nodes in the fiduciary subnet).
     #[serde(rename = "numSubnetNodes")]
     pub num_subnet_nodes: Option<NumSubnetNodes>,
-    /// Mode of operation. Default is `Mode::Normal`.
+    /// Mode of operation.
+    /// Default is `Mode::Normal`.
     pub mode: Option<Mode>,
 }
 


### PR DESCRIPTION
(XC-405) Improve docs for `InstallArgs` in the Candid file and rustdoc of the SOL RPC canister. Namely, better explain the default behavior when a field is not specified.