### PR TITLE
feat!: add `try_send` method to SOL RPC client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1042,9 +1042,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.3"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+checksum = "373b7c5dbd637569a2cca66e8d66b8c446a1e7bf064ea321d265d7b3dfe7c97e"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1337,11 +1337,11 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
- "curve25519-dalek 4.1.3",
+ "curve25519-dalek 4.2.0",
  "ed25519 2.2.3",
  "merlin",
  "rand_core 0.6.4",
@@ -1493,9 +1493,9 @@ dependencies = [
 
 [[package]]
 name = "fiat-crypto"
-version = "0.2.9"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "five8"
@@ -1934,7 +1934,7 @@ dependencies = [
  "http 1.3.1",
  "hyper",
  "hyper-util",
- "rustls 0.23.28",
+ "rustls 0.23.29",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
@@ -2100,8 +2100,8 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0a381e86a9d559c816a7ff4419e56f5d37f96357258fb63b0cb7026db0f729b"
 dependencies = [
- "curve25519-dalek 4.1.3",
- "ed25519-dalek 2.1.1",
+ "curve25519-dalek 4.2.0",
+ "ed25519-dalek 2.2.0",
  "hkdf",
  "pem 1.1.1",
  "rand 0.8.5",
@@ -3417,7 +3417,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.28",
+ "rustls 0.23.29",
  "socket2",
  "thiserror 2.0.12",
  "tokio",
@@ -3438,7 +3438,7 @@ dependencies = [
  "rand 0.9.1",
  "ring",
  "rustc-hash",
- "rustls 0.23.28",
+ "rustls 0.23.29",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "slab",
@@ -3730,7 +3730,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.28",
+ "rustls 0.23.29",
  "rustls-native-certs",
  "rustls-pki-types",
  "serde",
@@ -3847,14 +3847,14 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.28"
+version = "0.23.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643"
+checksum = "2491382039b29b9b11ff08b76ff6c97cf287671dbb74f0be44bda389fffe9bd1"
 dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.3",
+ "rustls-webpki 0.103.4",
  "subtle",
  "zeroize",
 ]
@@ -3892,10 +3892,10 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.28",
+ "rustls 0.23.29",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.3",
+ "rustls-webpki 0.103.4",
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
@@ -3920,9 +3920,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.3"
+version = "0.103.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
+checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -5235,7 +5235,7 @@ dependencies = [
  "bv",
  "bytes",
  "caps",
- "curve25519-dalek 4.1.3",
+ "curve25519-dalek 4.2.0",
  "dlopen2",
  "fnv",
  "libc",
@@ -5413,7 +5413,7 @@ dependencies = [
  "borsh 1.5.7",
  "bytemuck",
  "bytemuck_derive",
- "curve25519-dalek 4.1.3",
+ "curve25519-dalek 4.2.0",
  "five8",
  "five8_const",
  "num-traits",
@@ -5466,7 +5466,7 @@ dependencies = [
  "log",
  "quinn",
  "quinn-proto",
- "rustls 0.23.28",
+ "rustls 0.23.29",
  "solana-connection-cache",
  "solana-keypair",
  "solana-measure",
@@ -5894,7 +5894,7 @@ dependencies = [
  "quinn",
  "quinn-proto",
  "rand 0.8.5",
- "rustls 0.23.28",
+ "rustls 0.23.29",
  "smallvec",
  "socket2",
  "solana-keypair",
@@ -6022,7 +6022,7 @@ version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c792c9faa6f3fe5fb94dfcaeb3d65f5c7d84e58e0b1baf547a34c504dfae7797"
 dependencies = [
- "rustls 0.23.28",
+ "rustls 0.23.29",
  "solana-keypair",
  "solana-pubkey",
  "solana-signer",
@@ -6606,7 +6606,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
- "rustls 0.23.28",
+ "rustls 0.23.29",
  "tokio",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -668,9 +668,9 @@ dependencies = [
 
 [[package]]
 name = "canhttp"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b9cf652e717488c8a3ded473a04e577f9446f1d80adc81fbbce0642de786939"
+checksum = "b30b89e93857ec22d9b5f11b1647cdf9bb28c328e1d5ae871ecba2d94e38f8fb"
 dependencies = [
  "assert_matches",
  "ciborium",
@@ -4416,6 +4416,7 @@ dependencies = [
  "derive_more",
  "ic-cdk",
  "ic-ed25519",
+ "ic-error-types",
  "serde",
  "serde_json",
  "sol_rpc_types",
@@ -4446,6 +4447,7 @@ dependencies = [
  "candid",
  "ic-agent",
  "ic-cdk",
+ "ic-error-types",
  "serde",
  "serde_json",
  "sol_rpc_client",
@@ -4476,6 +4478,7 @@ dependencies = [
  "const_format",
  "futures",
  "ic-cdk",
+ "ic-error-types",
  "ic-http-types",
  "ic-management-canister-types",
  "ic-metrics-assert",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ bincode = "1.3.3"
 bs58 = "0.5.0"
 candid = "0.10.13"
 candid_parser = "0.1.4"
-canhttp = { version = "0.2.1" }
+canhttp = { version = "0.2.0" }
 canlog = { version = "0.1.0", features = ["derive"] }
 ciborium = "0.2.2"
 const_format = "0.2.34"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ bincode = "1.3.3"
 bs58 = "0.5.0"
 candid = "0.10.13"
 candid_parser = "0.1.4"
-canhttp = { version = "0.2.0" }
+canhttp = { version = "0.2.1" }
 canlog = { version = "0.1.0", features = ["derive"] }
 ciborium = "0.2.2"
 const_format = "0.2.34"

--- a/end_to_end_tests/Cargo.toml
+++ b/end_to_end_tests/Cargo.toml
@@ -12,6 +12,7 @@ async-trait = { workspace = true }
 candid = { workspace = true }
 ic-agent = { workspace = true }
 ic-cdk = { workspace = true }
+ic-error-types = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sol_rpc_client = { path = "../libs/client", features = ["ed25519"] }

--- a/end_to_end_tests/src/lib.rs
+++ b/end_to_end_tests/src/lib.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use candid::{utils::ArgumentEncoder, CandidType, Encode, Principal};
 use ic_agent::{identity::Secp256k1Identity, Agent};
-use ic_cdk::api::call::RejectionCode;
+use ic_error_types::RejectCode;
 use serde::de::DeserializeOwned;
 use serde_json::json;
 use sol_rpc_client::{ClientBuilder, Runtime, SolRpcClient};
@@ -216,7 +216,7 @@ impl Runtime for IcAgentRuntime<'_> {
         method: &str,
         args: In,
         cycles: u128,
-    ) -> Result<Out, (RejectionCode, String)>
+    ) -> Result<Out, (RejectCode, String)>
     where
         In: ArgumentEncoder + Send,
         Out: CandidType + DeserializeOwned,
@@ -228,7 +228,7 @@ impl Runtime for IcAgentRuntime<'_> {
             .with_arg(Encode!(&CallCanisterArgs::new(id, method, args, cycles)).unwrap())
             .call_and_wait()
             .await
-            .map_err(|e| (RejectionCode::Unknown, e.to_string()))?;
+            .map_err(|e| (RejectCode::SysFatal, e.to_string()))?;
         decode_cycles_wallet_response(result)
     }
 
@@ -237,7 +237,7 @@ impl Runtime for IcAgentRuntime<'_> {
         id: Principal,
         method: &str,
         args: In,
-    ) -> Result<Out, (RejectionCode, String)>
+    ) -> Result<Out, (RejectCode, String)>
     where
         In: ArgumentEncoder + Send,
         Out: CandidType + DeserializeOwned,
@@ -248,7 +248,7 @@ impl Runtime for IcAgentRuntime<'_> {
             .with_arg(encode_args(args))
             .call()
             .await
-            .map_err(|e| (RejectionCode::Unknown, e.to_string()))?;
+            .map_err(|e| (RejectCode::SysFatal, e.to_string()))?;
         decode_call_response(result)
     }
 }

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -15,6 +15,7 @@ canlog = { workspace = true }
 const_format = { workspace = true }
 futures = { workspace = true }
 ic-cdk = { workspace = true }
+ic-error-types = { workspace = true }
 ic-http-types = { workspace = true }
 ic-management-canister-types = { workspace = true }
 ic-metrics-assert = { workspace = true, features = ["pocket_ic"] }

--- a/libs/client/Cargo.toml
+++ b/libs/client/Cargo.toml
@@ -28,6 +28,7 @@ candid = { workspace = true }
 derive_more = { workspace = true }
 ic-cdk = { workspace = true }
 ic-ed25519 = { workspace = true, optional = true }
+ic-error-types = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sol_rpc_types = { version = "1.0.0", path = "../types" }

--- a/libs/client/src/ed25519.rs
+++ b/libs/client/src/ed25519.rs
@@ -6,13 +6,11 @@
 use crate::Runtime;
 use candid::Principal;
 use derive_more::{From, Into};
-use ic_cdk::api::{
-    call::RejectionCode,
-    management_canister::schnorr::{
-        SchnorrAlgorithm, SchnorrKeyId, SchnorrPublicKeyArgument, SchnorrPublicKeyResponse,
-        SignWithSchnorrArgument, SignWithSchnorrResponse,
-    },
+use ic_cdk::api::management_canister::schnorr::{
+    SchnorrAlgorithm, SchnorrKeyId, SchnorrPublicKeyArgument, SchnorrPublicKeyResponse,
+    SignWithSchnorrArgument, SignWithSchnorrResponse,
 };
+use ic_error_types::RejectCode;
 
 // Source: https://internetcomputer.org/docs/current/references/t-sigs-how-it-works/#fees-for-the-t-schnorr-test-key
 const SIGN_WITH_SCHNORR_TEST_FEE: u128 = 10_000_000_000;
@@ -166,7 +164,7 @@ pub async fn sign_message<R: Runtime>(
     message: &solana_message::Message,
     key_id: Ed25519KeyId,
     derivation_path: Option<&DerivationPath>,
-) -> Result<solana_signature::Signature, (RejectionCode, String)> {
+) -> Result<solana_signature::Signature, (RejectCode, String)> {
     let arg = SignWithSchnorrArgument {
         message: message.serialize(),
         derivation_path: derivation_path.cloned().unwrap_or_default().into(),
@@ -255,7 +253,7 @@ pub async fn get_pubkey<R: Runtime>(
     canister_id: Option<Principal>,
     derivation_path: Option<&DerivationPath>,
     key_id: Ed25519KeyId,
-) -> Result<(solana_pubkey::Pubkey, [u8; 32]), (RejectionCode, String)> {
+) -> Result<(solana_pubkey::Pubkey, [u8; 32]), (RejectCode, String)> {
     let arg = SchnorrPublicKeyArgument {
         canister_id,
         derivation_path: derivation_path.cloned().unwrap_or_default().into(),

--- a/libs/client/src/fixtures/mod.rs
+++ b/libs/client/src/fixtures/mod.rs
@@ -5,7 +5,7 @@
 use crate::{ClientBuilder, Runtime};
 use async_trait::async_trait;
 use candid::{utils::ArgumentEncoder, CandidType, Decode, Encode, Principal};
-use ic_cdk::api::call::RejectionCode;
+use ic_error_types::RejectCode;
 use serde::de::DeserializeOwned;
 use sol_rpc_types::{AccountData, AccountEncoding, AccountInfo};
 use std::collections::BTreeMap;
@@ -83,7 +83,7 @@ impl MockRuntime {
         self
     }
 
-    fn call<Out>(&self, method: &str) -> Result<Out, (RejectionCode, String)>
+    fn call<Out>(&self, method: &str) -> Result<Out, (RejectCode, String)>
     where
         Out: CandidType + DeserializeOwned,
     {
@@ -110,7 +110,7 @@ impl Runtime for MockRuntime {
         method: &str,
         _args: In,
         _cycles: u128,
-    ) -> Result<Out, (RejectionCode, String)>
+    ) -> Result<Out, (RejectCode, String)>
     where
         In: ArgumentEncoder + Send,
         Out: CandidType + DeserializeOwned,
@@ -123,7 +123,7 @@ impl Runtime for MockRuntime {
         _id: Principal,
         method: &str,
         _args: In,
-    ) -> Result<Out, (RejectionCode, String)>
+    ) -> Result<Out, (RejectCode, String)>
     where
         In: ArgumentEncoder + Send,
         Out: CandidType + DeserializeOwned,

--- a/libs/client/src/lib.rs
+++ b/libs/client/src/lib.rs
@@ -1234,6 +1234,8 @@ fn convert_reject_code(code: IcCdkRejectionCode) -> RejectCode {
             // In particular, note that RejectCode::SysUnknown is only applicable to inter-canister calls that used ic0.call_with_best_effort_response.
             RejectCode::SysFatal
         }
-        IcCdkRejectionCode::NoError => unreachable!("inter-canister calls should never produce a RejectionCode::NoError error")
+        IcCdkRejectionCode::NoError => {
+            unreachable!("inter-canister calls should never produce a RejectionCode::NoError error")
+        }
     }
 }

--- a/libs/client/src/lib.rs
+++ b/libs/client/src/lib.rs
@@ -142,7 +142,8 @@ use crate::request::{
 };
 use async_trait::async_trait;
 use candid::{utils::ArgumentEncoder, CandidType, Principal};
-use ic_cdk::api::call::RejectionCode;
+use ic_cdk::api::call::RejectionCode as IcCdkRejectionCode;
+use ic_error_types::RejectCode;
 pub use request::{
     EstimateBlockhashRequestBuilder, EstimateRecentBlockhashError, Request, RequestBuilder,
     SolRpcEndpoint, SolRpcRequest,
@@ -155,6 +156,7 @@ use sol_rpc_types::{
     SendTransactionParams, SolanaCluster, SupportedRpcProvider, SupportedRpcProviderId,
 };
 use std::{fmt::Debug, sync::Arc};
+
 /// The principal identifying the productive Solana RPC canister under NNS control.
 ///
 /// ```rust
@@ -178,7 +180,7 @@ pub trait Runtime {
         method: &str,
         args: In,
         cycles: u128,
-    ) -> Result<Out, (RejectionCode, String)>
+    ) -> Result<Out, (RejectCode, String)>
     where
         In: ArgumentEncoder + Send,
         Out: CandidType + DeserializeOwned;
@@ -189,7 +191,7 @@ pub trait Runtime {
         id: Principal,
         method: &str,
         args: In,
-    ) -> Result<Out, (RejectionCode, String)>
+    ) -> Result<Out, (RejectCode, String)>
     where
         In: ArgumentEncoder + Send,
         Out: CandidType + DeserializeOwned;
@@ -1125,6 +1127,21 @@ impl<R: Runtime> SolRpcClient<R> {
         Params: CandidType + Send,
         CandidOutput: Into<Output> + CandidType + DeserializeOwned,
     {
+        let rpc_method = request.endpoint.rpc_method();
+        self.try_execute_request(request)
+            .await
+            .unwrap_or_else(|e| panic!("Client error: failed to call `{}`: {e:?}", rpc_method))
+    }
+
+    async fn try_execute_request<Config, Params, CandidOutput, Output>(
+        &self,
+        request: Request<Config, Params, CandidOutput, Output>,
+    ) -> Result<Output, (RejectCode, String)>
+    where
+        Config: CandidType + Send,
+        Params: CandidType + Send,
+        CandidOutput: Into<Output> + CandidType + DeserializeOwned,
+    {
         self.config
             .runtime
             .update_call::<(RpcSources, Option<Config>, Params), CandidOutput>(
@@ -1134,13 +1151,7 @@ impl<R: Runtime> SolRpcClient<R> {
                 request.cycles,
             )
             .await
-            .unwrap_or_else(|e| {
-                panic!(
-                    "Client error: failed to call `{}`: {e:?}",
-                    request.endpoint.rpc_method()
-                )
-            })
-            .into()
+            .map(Into::into)
     }
 
     async fn execute_cycles_cost_request<Config, Params, CandidOutput, Output>(
@@ -1182,7 +1193,7 @@ impl Runtime for IcRuntime {
         method: &str,
         args: In,
         cycles: u128,
-    ) -> Result<Out, (RejectionCode, String)>
+    ) -> Result<Out, (RejectCode, String)>
     where
         In: ArgumentEncoder + Send,
         Out: CandidType + DeserializeOwned,
@@ -1190,6 +1201,7 @@ impl Runtime for IcRuntime {
         ic_cdk::api::call::call_with_payment128(id, method, args, cycles)
             .await
             .map(|(res,)| res)
+            .map_err(|(code, message)| (convert_reject_code(code), message))
     }
 
     async fn query_call<In, Out>(
@@ -1197,7 +1209,7 @@ impl Runtime for IcRuntime {
         id: Principal,
         method: &str,
         args: In,
-    ) -> Result<Out, (RejectionCode, String)>
+    ) -> Result<Out, (RejectCode, String)>
     where
         In: ArgumentEncoder + Send,
         Out: CandidType + DeserializeOwned,
@@ -1205,5 +1217,23 @@ impl Runtime for IcRuntime {
         ic_cdk::api::call::call(id, method, args)
             .await
             .map(|(res,)| res)
+            .map_err(|(code, message)| (convert_reject_code(code), message))
+    }
+}
+
+fn convert_reject_code(code: IcCdkRejectionCode) -> RejectCode {
+    match code {
+        IcCdkRejectionCode::SysFatal => RejectCode::SysFatal,
+        IcCdkRejectionCode::SysTransient => RejectCode::SysTransient,
+        IcCdkRejectionCode::DestinationInvalid => RejectCode::DestinationInvalid,
+        IcCdkRejectionCode::CanisterReject => RejectCode::CanisterReject,
+        IcCdkRejectionCode::CanisterError => RejectCode::CanisterError,
+        IcCdkRejectionCode::Unknown => {
+            // This can only happen if there is a new error code on ICP that the CDK is not aware of.
+            // We map it to SysFatal since none of the other error codes apply.
+            // In particular, note that RejectCode::SysUnknown is only applicable to inter-canister calls that used ic0.call_with_best_effort_response.
+            RejectCode::SysFatal
+        }
+        IcCdkRejectionCode::NoError => unreachable!("ic_cdk::api::management_canister::http_request::http_request should never produce a RejectionCode::NoError error")
     }
 }

--- a/libs/client/src/lib.rs
+++ b/libs/client/src/lib.rs
@@ -1234,6 +1234,6 @@ fn convert_reject_code(code: IcCdkRejectionCode) -> RejectCode {
             // In particular, note that RejectCode::SysUnknown is only applicable to inter-canister calls that used ic0.call_with_best_effort_response.
             RejectCode::SysFatal
         }
-        IcCdkRejectionCode::NoError => unreachable!("ic_cdk::api::management_canister::http_request::http_request should never produce a RejectionCode::NoError error")
+        IcCdkRejectionCode::NoError => unreachable!("inter-canister calls should never produce a RejectionCode::NoError error")
     }
 }


### PR DESCRIPTION
Add a `try_send` method to the client in `sol_rpc_client` that doesn't panic if sending the request fails and instead returns the resulting error. The bulk of this change involves a refactoring to use `ic_error_types::RejectCode` instead of `ic_cdk::api::call::RejectionCode` wherever possible in the repository.

BREAKING CHANGE: Various public methods now return a `Result<(..., (ic_error_types::RejectCode, String))>` instead of a `Result<(..., (ic_cdk::api::call::RejectionCode, String))>` previously.