### PR TITLE
docs: remove warning in top-level README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,6 @@
 
 # SOL RPC canister
 
-> [!IMPORTANT]  
-> The SOL RPC canister and its associated libraries are under active development and are subject to change. Access to the repositories has been opened to allow for early feedback. Check back regularly for updates.
->
-> Please share your feedback on the [developer forum](https://forum.dfinity.org/t/sol-rpc-canister/41896).
-
-
 Interact with the [Solana](https://solana.com/) blockchain from the [Internet Computer](https://internetcomputer.org/).
 
 ## Table of Contents
@@ -243,6 +237,7 @@ In order to verify the latest SOL RPC Wasm file, please make sure to download th
 
 * :movie_camera: [Demo](https://youtu.be/CpxQqp6CxoY?feature=shared) that runs through most parts of the [basic_solana](examples/basic_solana) example.
 * :newspaper: Blog post [ICP Reaches the Shores of Solana](https://medium.com/dfinity/icp-reaches-the-shores-of-solana-0f373a886dce).
+* :loudspeaker: [Forum post](https://forum.dfinity.org/t/sol-rpc-canister/41896) on the developer forum.
 
 ## Related Projects
 


### PR DESCRIPTION
Remove warning that the SOL RPC canister and its associated libraries are under active development from the top-level README.