### PR TITLE
build: enable `cargo publish` for `sol_rpc_canister`

### DIFF
--- a/canister/Cargo.toml
+++ b/canister/Cargo.toml
@@ -7,7 +7,6 @@ edition.workspace = true
 repository.workspace = true
 homepage.workspace = true
 license.workspace = true
-publish = false
 
 [[bin]]
 name = "sol_rpc_canister"

--- a/canister/Cargo.toml
+++ b/canister/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 repository.workspace = true
 homepage.workspace = true
 license.workspace = true
+publish = false
 
 [[bin]]
 name = "sol_rpc_canister"

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -34,7 +34,6 @@ name = "sol_rpc_canister"
 semver_check = false # disable API breaking changes checks
 release = true
 publish = false # disable `cargo publish`
-initial_version = "1.0.0"
 
 [[package]] # the double square brackets define a TOML table array
 name = "sol_rpc_client"

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -32,7 +32,7 @@ publish_allow_dirty = false
 [[package]] # the double square brackets define a TOML table array
 name = "sol_rpc_canister"
 semver_check = false # disable API breaking changes checks
-publish = false # disable `cargo publish`
+publish = true # enable `cargo publish`
 
 [[package]] # the double square brackets define a TOML table array
 name = "sol_rpc_client"

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -32,16 +32,18 @@ publish_allow_dirty = false
 [[package]] # the double square brackets define a TOML table array
 name = "sol_rpc_canister"
 semver_check = false # disable API breaking changes checks
-publish = true # enable `cargo publish`
+release = true
+publish = false # disable `cargo publish`
+initial_version = "1.0.0"
 
 [[package]] # the double square brackets define a TOML table array
 name = "sol_rpc_client"
-#git_release_enable = false # enable GitHub releases
+#git_release_enable = false # disable GitHub releaseschangelog = true
 publish = true # enable `cargo publish`
 
 [[package]] # the double square brackets define a TOML table array
 name = "sol_rpc_types"
-#git_release_enable = false # enable GitHub releases
+#git_release_enable = false # disable GitHub releases
 publish = true # enable `cargo publish`
 
 [[package]]


### PR DESCRIPTION
Currently, `publish` is set to `false` in the `release-plz` configuration for the `sol_rpc_canister` crate. This is because `sol_rpc_canister` is a binary crate and should not be published to [crates.io](https://crates.io/). However, this has the disadvantage of `release-plz` not generating a changelog and bumping the version for the `sol_rpc_canister` crate.

Instead, set `publish = true` for the `sol_rpc_canister` crate in `release-plz.toml` and `publish = false` in the `Cargo.toml` for the `sol_rpc_canister` crate. This means `release-plz` is run (hence generating the changelog and bumping the version) but the crate is not published to [crates.io](https://crates.io/).