### PR TITLE
docs: Add link to ICP Ninja in `basic_solana` README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Interact with the [Solana](https://solana.com/) blockchain from the [Internet Co
 * [Deployment](#deployment)
   * [Deployment to the IC](#deployment-to-the-ic)
   * [Local deployment](#local-deployment)
+  * [Deploying from ICP Ninja](#deploying-from-icp-ninja)
 * [Limitations](#limitations)
 * [Supported Methods](#supported-methods)
 * [Supported Solana JSON-RPC Providers](#supported-solana-json-rpc-providers)

--- a/README.md
+++ b/README.md
@@ -173,6 +173,15 @@ dfx start --background
 dfx deploy sol_rpc
 ```
 
+### Deploying from ICP Ninja
+
+To deploy the SOL RPC canister together with an example Solana wallet smart contract using ICP Ninja, click on the following link:
+
+[![](https://icp.ninja/assets/open.svg)](https://icp.ninja/editor?g=https://github.com/dfinity/sol-rpc-canister/tree/main/examples/basic_solana/ninja)
+
+> [!TIP]
+> If you download the project from ICP Ninja to deploy it locally, you will need to change the `init_arg` for the `basic_solana` canister in the `dfx.json` file. Specifically, you will need to change `ed25519_key_name = opt variant { MainnetTestKey1 }` to `ed25519_key_name = opt variant { LocalDevelopment }`. To learn more about the initialization arguments, see the `InitArg` type in [`basic_solana.did`](basic_solana.did).
+
 ## Limitations
 
 The SOL RPC canister reaches the Solana JSON-RPC providers using [HTTPS outcalls](https://internetcomputer.org/https-outcalls) and are therefore subject to the following limitations:

--- a/examples/basic_solana/README.md
+++ b/examples/basic_solana/README.md
@@ -87,6 +87,15 @@ What this does:
 > [!TIP]
 > To target Solana Mainnet, you will need to change the `init_arg` for the `basic_solana` canister in the `dfx.json` file. To learn more about the initialization arguments, see the `InitArg` type in [`basic_solana.did`](basic_solana.did).
 
+#### Deploying from ICP Ninja
+
+To deploy the Solana wallet smart contract using ICP Ninja, click on the following link:
+
+[![](https://icp.ninja/assets/open.svg)](https://icp.ninja/editor?g=https://github.com/dfinity/sol-rpc-canister/tree/main/examples/basic_solana/ninja)
+
+> [!TIP]
+> If you download the project from ICP Ninja to deploy it locally, you will need to change the `init_arg` for the `basic_solana` canister in the `dfx.json` file. Specifically, you will need to change `ed25519_key_name = opt variant { MainnetTestKey1 }` to `ed25519_key_name = opt variant { LocalDevelopment }`. To learn more about the initialization arguments, see the `InitArg` type in [`basic_solana.did`](basic_solana.did).
+
 ### Getting the canister ID
 
 If the canister deployment is successful (whether on Mainnet or locally), you should see an output that looks like this:


### PR DESCRIPTION
(XC-453) Add "Deployment to ICP Ninja" section including button with link in `basic_solana` README.