### PR TITLE
fix: release pipeline

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -67,13 +67,16 @@ jobs:
       - name: "Install parse-changelog"
         uses: taiki-e/install-action@parse-changelog
 
+      - name: "Install release-plz from fork"
+        run: |
+          git clone https://github.com/lpahlavi/release-plz.git /tmp/release-plz-fork
+          cd /tmp/release-plz-fork
+          git checkout 9b511999ed04cc5070fe5efcd5481b6b2cc035c1
+          cargo +1.88.0 install --path crates/release_plz
+
       - name: "Run release-plz"
-        id: release-plz
-        uses: lpahlavi/release-plz/action@bd11ce7ef1683c1b4dd359b57c867cfdf3e04f4a # https://github.com/release-plz/release-plz/pull/2357
-        with:
-          command: release
+        run: release-plz release --git-token ${{ secrets.GITHUB_TOKEN }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
       - name: "Generate Github release body"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: "Run release-plz"
         id: release-plz
-        uses: release-plz/action@8724d33cd97b8295051102e2e19ca592962238f5 # v0.5.108
+        uses: lpahlavi/release-plz/action@bd11ce7ef1683c1b4dd359b57c867cfdf3e04f4a # https://github.com/release-plz/release-plz/pull/2357
         with:
           command: release
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,16 +19,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@v1
-        with:
-          toolchain: nightly
       - name: Install release-plz from fork
         run: |
           git clone https://github.com/lpahlavi/release-plz.git /tmp/release-plz-fork
           cd /tmp/release-plz-fork
           git checkout 9b511999ed04cc5070fe5efcd5481b6b2cc035c1
-          cargo +nightly install --path crates/release_plz
+          cargo +1.88.0 install --path crates/release_plz
       - name: Run release-plz
         run: release-plz release-pr --git-token ${{ secrets.GITHUB_TOKEN }}
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,6 @@ jobs:
           git checkout bd11ce7ef1683c1b4dd359b57c867cfdf3e04f4a
           cargo +nightly install --path crates/release_plz
       - name: Run release-plz
-        run: release-plz release-pr
+        run: release-plz release-pr --git-token ${{ secrets.GITHUB_TOKEN }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,13 +22,13 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@v1
         with:
-          toolchain: nightly-2024-07-01
+          toolchain: nightly
       - name: Install release-plz from fork
         run: |
           git clone https://github.com/lpahlavi/release-plz.git /tmp/release-plz-fork
           cd /tmp/release-plz-fork
           git checkout bd11ce7ef1683c1b4dd359b57c867cfdf3e04f4a
-          cargo +nightly-2024-07-01 install --path crates/release_plz
+          cargo +nightly install --path crates/release_plz
       - name: Run release-plz
         run: release-plz release-pr
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           git clone https://github.com/lpahlavi/release-plz.git /tmp/release-plz-fork
           cd /tmp/release-plz-fork
-          git checkout bd11ce7ef1683c1b4dd359b57c867cfdf3e04f4a
+          git checkout 9b511999ed04cc5070fe5efcd5481b6b2cc035c1
           cargo +nightly install --path crates/release_plz
       - name: Run release-plz
         run: release-plz release-pr --git-token ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Run release-plz
-        uses: release-plz/action@8724d33cd97b8295051102e2e19ca592962238f5 # v0.5.108
+        uses: lpahlavi/release-plz/action@bd11ce7ef1683c1b4dd359b57c867cfdf3e04f4a # https://github.com/release-plz/release-plz/pull/2357
         with:
           command: release-pr
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,9 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@nightly-2024-07-01
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: nightly-2024-07-01
       - name: Install release-plz from fork
         run: |
           cargo install --git https://github.com/lpahlavi/release-plz --rev bd11ce7ef1683c1b4dd359b57c867cfdf3e04f4a release-plz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@nightly-2024-07-01
       - name: Install release-plz from fork
         run: |
           cargo install --git https://github.com/lpahlavi/release-plz --rev bd11ce7ef1683c1b4dd359b57c867cfdf3e04f4a release-plz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,10 @@ jobs:
           toolchain: nightly-2024-07-01
       - name: Install release-plz from fork
         run: |
-          cargo +nightly-2024-07-01 install --git https://github.com/lpahlavi/release-plz --rev bd11ce7ef1683c1b4dd359b57c867cfdf3e04f4a --path crates/release_plz
+          git clone https://github.com/lpahlavi/release-plz.git /tmp/release-plz-fork
+          cd /tmp/release-plz-fork
+          git checkout bd11ce7ef1683c1b4dd359b57c867cfdf3e04f4a
+          cargo +nightly-2024-07-01 install --path crates/release_plz
       - name: Run release-plz
         run: release-plz release-pr
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,10 +19,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Install release-plz from fork
+        run: |
+          cargo install --git https://github.com/lpahlavi/release-plz --rev bd11ce7ef1683c1b4dd359b57c867cfdf3e04f4a release-plz
       - name: Run release-plz
-        uses: lpahlavi/release-plz/action@bd11ce7ef1683c1b4dd359b57c867cfdf3e04f4a # https://github.com/release-plz/release-plz/pull/2357
-        with:
-          command: release-pr
+        run: release-plz release-pr
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           toolchain: nightly-2024-07-01
       - name: Install release-plz from fork
         run: |
-          cargo install --git https://github.com/lpahlavi/release-plz --rev bd11ce7ef1683c1b4dd359b57c867cfdf3e04f4a release-plz
+          cargo +nightly-2024-07-01 install --git https://github.com/lpahlavi/release-plz --rev bd11ce7ef1683c1b4dd359b57c867cfdf3e04f4a release-plz
       - name: Run release-plz
         run: release-plz release-pr
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@nightly
       - name: Install release-plz from fork
         run: |
           cargo install --git https://github.com/lpahlavi/release-plz --rev bd11ce7ef1683c1b4dd359b57c867cfdf3e04f4a release-plz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           toolchain: nightly-2024-07-01
       - name: Install release-plz from fork
         run: |
-          cargo +nightly-2024-07-01 install --git https://github.com/lpahlavi/release-plz --rev bd11ce7ef1683c1b4dd359b57c867cfdf3e04f4a release-plz
+          cargo +nightly-2024-07-01 install --git https://github.com/lpahlavi/release-plz --rev bd11ce7ef1683c1b4dd359b57c867cfdf3e04f4a --path crates/release_plz
       - name: Run release-plz
         run: release-plz release-pr
         env:

--- a/canister/Cargo.toml
+++ b/canister/Cargo.toml
@@ -7,7 +7,6 @@ edition.workspace = true
 repository.workspace = true
 homepage.workspace = true
 license.workspace = true
-publish = false
 
 [[bin]]
 name = "sol_rpc_canister"

--- a/canister/Cargo.toml
+++ b/canister/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 repository.workspace = true
 homepage.workspace = true
 license.workspace = true
+publish = false
 
 [[bin]]
 name = "sol_rpc_canister"


### PR DESCRIPTION
Currently, `release-plz` runs into issues when trying to determine the next version of the `sol_rpc_canister` crate. This is because the `sol_rpc_canister` crate is a binary crate and hence not published on [crates.io](crates.io). However, since a release tag exists for the crate, `release-plz` tries to download the latest release from [crates.io](crates.io) and fails. See [this failed release pipeline run](https://github.com/dfinity/sol-rpc-canister/actions/runs/17233112571) for example.

I've opened [a PR](https://github.com/release-plz/release-plz/pull/2357) to fix this issue in the upstream release-plz repository, and updated the release pipeline here to build the release-plz GitHub action from source to include those changes. This is a temporary solution until the changes are merged in the upstream repository. The release pipeline runs again successfully when using the patched release-plz GitHub action (see [this run](https://github.com/dfinity/sol-rpc-canister/actions/runs/17321578196)).