### PR TITLE
docs: expand `basic_solana` tip on local usage from ICP Ninja

### DIFF
--- a/examples/basic_solana/README.md
+++ b/examples/basic_solana/README.md
@@ -94,7 +94,12 @@ To deploy the Solana wallet smart contract using ICP Ninja, click on the followi
 [![](https://icp.ninja/assets/open.svg)](https://icp.ninja/editor?g=https://github.com/dfinity/sol-rpc-canister/tree/main/examples/basic_solana/ninja)
 
 > [!TIP]
-> If you download the project from ICP Ninja to deploy it locally, you will need to change the `init_arg` for the `basic_solana` canister in the `dfx.json` file. Specifically, you will need to change `ed25519_key_name = opt variant { MainnetTestKey1 }` to `ed25519_key_name = opt variant { LocalDevelopment }`. To learn more about the initialization arguments, see the `InitArg` type in [`basic_solana.did`](basic_solana.did).
+> If you downloaded the project from ICP Ninja to run it locally, you’ll need to update the `init_arg` for the `basic_solana` canister in `dfx.json`:
+>
+> - Change the key name from `ed25519_key_name = opt variant { MainnetTestKey1 }` to `ed25519_key_name = opt variant { LocalDevelopment }`.
+> - To use the public Solana Labs RPC endpoint instead of the default RPC providers (which require a valid API key), replace `solana_network = opt variant { Devnet }` with `solana_network = opt variant { Custom = record { url = "https://api.devnet.solana.com"; headers = null } }`, or use the URL for the cluster you want, as documented [here](https://solana.com/docs/references/clusters).
+>
+> For more details, see the `InitArg` type in [`basic_solana.did`](basic_solana.did).
 
 ### Getting the canister ID
 


### PR DESCRIPTION
Expand the tip on deployment of the `basic_solana` example after downloading it from ICP Ninja by mentioning how to adapt the `solana_network` `init_arg` value to use a public RPC endpoint.