### PR TITLE
ci: re-enable `check-ninja-cargo-toml` in CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,20 +34,19 @@ jobs:
       - name: 'Check Cargo.toml'
         run: cargo sort --workspace --check
 
-# TODO XC-456: Re-enable once `sol_rpc_client` v3.0.0 is released and ICP Ninja deployment of `basic_solana` is reverted
-#  check-ninja-cargo-toml:
-#    runs-on: ubuntu-latest
-#    steps:
-#      - name: 'Checkout'
-#        uses: actions/checkout@v4
-#
-#      - name: 'Set up Python'
-#        uses: actions/setup-python@v5
-#        with:
-#          python-version: '3.11'
-#
-#      - name: 'Check ninja Cargo.toml'
-#        run: python3 .github/scripts/check_ninja_cargo_toml.py
+  check-ninja-cargo-toml:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v4
+
+      - name: 'Set up Python'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: 'Check ninja Cargo.toml'
+        run: python3 .github/scripts/check_ninja_cargo_toml.py
 
   check-cargo-lock:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,20 +34,6 @@ jobs:
       - name: 'Check Cargo.toml'
         run: cargo sort --workspace --check
 
-  check-ninja-cargo-toml:
-    runs-on: ubuntu-latest
-    steps:
-      - name: 'Checkout'
-        uses: actions/checkout@v4
-
-      - name: 'Set up Python'
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-
-      - name: 'Check ninja Cargo.toml'
-        run: python3 .github/scripts/check_ninja_cargo_toml.py
-
   check-cargo-lock:
     runs-on: ubuntu-latest
     steps:
@@ -118,6 +104,14 @@ jobs:
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v4
+
+      - name: 'Set up Python'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: 'Check ninja Cargo.toml'
+        run: python3 .github/scripts/check_ninja_cargo_toml.py
 
       - name: 'Install dfx'
         uses: dfinity/setup-dfx@e50c04f104ee4285ec010f10609483cf41e4d365

--- a/examples/basic_solana/ninja/Cargo.toml
+++ b/examples/basic_solana/ninja/Cargo.toml
@@ -25,7 +25,7 @@ solana-hash = "3.0.0"
 solana-instruction = "3.0.0"
 solana-message = "3.0.0"
 solana-pubkey = { version = "3.0.0", features = ["curve25519"] }
-solana-signature = "3.0.0"
+solana-signature = "3.1.0"
 solana-system-interface = { version = "2.0.0", features = ["bincode"] }
 solana-transaction = { version = "3.0.0", features = ["bincode"] }
 spl-associated-token-account-interface = "2.0.0"


### PR DESCRIPTION
(XC-454) Since #222 was merged, re-enable the CI pipeline step to ensure the `Cargo.toml` for the ICP Ninja deployment of `basic_solana` is up-to-date, and group it with the other `icp-ninja-tests` added in #217.