### PR TITLE
ci: add `cargo-machete` to lint check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
           cargo sort --workspace --check
 
       - name: 'Run Cargo Machete'
-        uses: bnjbvr/cargo-machete@0.9.1
+        uses: bnjbvr/cargo-machete@v0.9.1
 
   check-cargo-lock:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Run [Cargo Machete](https://github.com/bnjbvr/cargo-machete) to check for unused dependencies during the linting step of the CI pipeline.