### PR TITLE
fix: do not ignore `response_size_estimate` for `getBlock`

### DIFF
--- a/canister/src/rpc_client/mod.rs
+++ b/canister/src/rpc_client/mod.rs
@@ -155,7 +155,9 @@ impl GetBlockRequest {
         let params = params.into();
         let consensus_strategy = config.response_consensus.unwrap_or_default();
         let providers = Providers::new(rpc_sources, consensus_strategy.clone(), now)?;
-        let max_response_bytes = Self::response_size_estimate(&params);
+        let max_response_bytes = config
+            .response_size_estimate
+            .unwrap_or(Self::response_size_estimate(&params));
 
         Ok(MultiRpcRequest::new(
             providers,


### PR DESCRIPTION
Previously, the `response_size_estimate` parameter in the RPC config was ignored when calling `getBlock` on the SOL RPC canister. This PR ensures that the value is properly respected.