### PR TITLE
ci: check canister endpoints with `ic-wasm`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,11 +151,11 @@ jobs:
           name: sol_rpc_canister.wasm.gz
 
       - name: 'Run IC WASM check-endpoints'
-        uses: dfinity/ic-wasm@d2d1f16f8636891d9a7da50862efa7f8535efcbd
+        uses: dfinity/ic-wasm@72c486f152273f549bcdca50b2297be4a7e0576e
         with:
           command: check-endpoints
           wasm: ${{ github.workspace }}/sol_rpc_canister.wasm.gz
-          hidden: ./canister/hidden_endpoints.txt
+          args: --hidden ./canister/hidden_endpoints.txt
 
   integration-tests:
     needs: [ reproducible-build ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,7 @@ jobs:
         with:
           command: check-endpoints
           wasm: ${{ github.workspace }}/sol_rpc_canister.wasm.gz
+          hidden: ./canister/hidden_endpoints.txt
 
   integration-tests:
     needs: [ reproducible-build ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,12 +150,14 @@ jobs:
         with:
           name: sol_rpc_canister.wasm.gz
 
-      - name: 'Run IC WASM check-endpoints'
-        uses: dfinity/ic-wasm@2f96a89ea51ecf69312b5fb2e85d5d1788a7b1cb
+      - name: 'Install `ic-wasm`'
+        uses: taiki-e/install-action@v2
         with:
-          command: check-endpoints
-          wasm: ${{ github.workspace }}/sol_rpc_canister.wasm.gz
-          args: --hidden ./canister/hidden_endpoints.txt
+          tool: ic-wasm
+
+      - name: 'Check canister endpoints'
+        run: |
+          ic-wasm "$GITHUB_WORKSPACE/sol_rpc_canister.wasm.gz" check-endpoints --hidden ./canister/hidden_endpoints.txt
 
   integration-tests:
     needs: [ reproducible-build ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,24 @@ jobs:
           echo "$out"
           echo "$out" | grep -Eq "[0-9]+(_[0-9]+)*" || { echo "❌ Call to 'get_balance' failed"; exit 1; }
 
+  check-canister-wasm-endpoints:
+    needs: [ reproducible-build ]
+    runs-on: ubuntu-22.04
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v4
+
+      - name: 'Download artifacts'
+        uses: actions/download-artifact@v4
+        with:
+          name: sol_rpc_canister.wasm.gz
+
+      - name: 'Run IC WASM check-endpoints'
+        uses: dfinity/ic-wasm@lpahlavi/XC-391-add-github-action
+        with:
+          command: check-endpoints
+          wasm: ${{ github.workspace }}/sol_rpc_canister.wasm.gz
+
   integration-tests:
     needs: [ reproducible-build ]
     runs-on: ubuntu-22.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,7 @@ jobs:
           name: sol_rpc_canister.wasm.gz
 
       - name: 'Run IC WASM check-endpoints'
-        uses: dfinity/ic-wasm@lpahlavi/XC-391-add-github-action
+        uses: dfinity/ic-wasm@d2d1f16f8636891d9a7da50862efa7f8535efcbd
         with:
           command: check-endpoints
           wasm: ${{ github.workspace }}/sol_rpc_canister.wasm.gz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,7 @@ jobs:
           name: sol_rpc_canister.wasm.gz
 
       - name: 'Run IC WASM check-endpoints'
-        uses: dfinity/ic-wasm@72c486f152273f549bcdca50b2297be4a7e0576e
+        uses: dfinity/ic-wasm@2f96a89ea51ecf69312b5fb2e85d5d1788a7b1cb
         with:
           command: check-endpoints
           wasm: ${{ github.workspace }}/sol_rpc_canister.wasm.gz

--- a/canister/hidden_endpoints.txt
+++ b/canister/hidden_endpoints.txt
@@ -1,0 +1,14 @@
+canister_query:cleanup_response
+canister_query:http_request
+canister_query:verifyApiKey
+canister_init
+canister_post_upgrade
+main
+rust_zstd_wasm_shim_calloc
+rust_zstd_wasm_shim_free
+rust_zstd_wasm_shim_malloc
+rust_zstd_wasm_shim_memcmp
+rust_zstd_wasm_shim_memcpy
+rust_zstd_wasm_shim_memmove
+rust_zstd_wasm_shim_memset
+rust_zstd_wasm_shim_qsort


### PR DESCRIPTION
This PR adds a step to the CI pipeline that runs `ic-wasm check-endpoints` to verify that there are no accidentally or maliciously exported canister endpoints in the canister's WASM.