### PR TITLE
fix: scale default attached cycles by number of providers

### DIFF
--- a/integration_tests/tests/tests.rs
+++ b/integration_tests/tests/tests.rs
@@ -474,7 +474,7 @@ mod generic_request_tests {
             request: RequestBuilder<Runtime, Config, Params, CandidOutput, Output>,
         ) where
             Runtime: ic_canister_runtime::Runtime,
-            Config: CandidType + Clone + Send,
+            Config: CandidType + Clone + Send + SolRpcConfig,
             Params: CandidType + Clone + Send,
             CandidOutput: Into<Output> + CandidType + DeserializeOwned,
             RequestBuilder<Runtime, Config, Params, CandidOutput, Output>: DefaultRequestCycles,
@@ -536,7 +536,7 @@ mod generic_request_tests {
             request: RequestBuilder<Runtime, Config, Params, CandidOutput, Output>,
         ) where
             Runtime: ic_canister_runtime::Runtime,
-            Config: CandidType + Clone + Send,
+            Config: CandidType + Clone + Send + SolRpcConfig,
             Params: CandidType + Clone + Send,
             CandidOutput: Into<Output> + CandidType + DeserializeOwned,
             RequestBuilder<Runtime, Config, Params, CandidOutput, Output>: DefaultRequestCycles,

--- a/integration_tests/tests/tests.rs
+++ b/integration_tests/tests/tests.rs
@@ -981,7 +981,7 @@ mod cycles_cost_tests {
             expected_cycles_cost: u128,
         ) where
             Runtime: ic_canister_runtime::Runtime,
-            Config: CandidType + Clone + Send,
+            Config: CandidType + Clone + Send + SolRpcConfig,
             Params: CandidType + Clone + Send,
             CandidOutput: CandidType + DeserializeOwned,
             Output: Debug,
@@ -998,6 +998,14 @@ mod cycles_cost_tests {
 
             let cycles_cost = request.clone().request_cost().send().await.unwrap();
             assert_within(cycles_cost, expected_cycles_cost, five_percents);
+
+            let default_cycles = request
+                .default_request_cycles()
+                .saturating_mul(request.num_providers() as u128);
+            assert!(
+                default_cycles >= cycles_cost,
+                "BUG: default cycles ({default_cycles}) are less than the actual cost ({cycles_cost})"
+            );
 
             let cycles_before = setup.sol_rpc_canister_cycles_balance().await;
             // Request with exact cycles amount should succeed

--- a/libs/client/src/request/mod.rs
+++ b/libs/client/src/request/mod.rs
@@ -917,7 +917,7 @@ impl<Runtime, Config: SolRpcConfig, Params, CandidOutput, Output>
     RequestBuilder<Runtime, Config, Params, CandidOutput, Output>
 {
     /// Return the number of providers that will be queried for this request.
-    pub(crate) fn num_providers(&self) -> u32 {
+    pub fn num_providers(&self) -> u32 {
         /// Default number of providers queried when using default RPC sources.
         const DEFAULT_NUM_PROVIDERS: u32 = 3;
 

--- a/libs/client/src/request/mod.rs
+++ b/libs/client/src/request/mod.rs
@@ -150,7 +150,7 @@ pub type GetAccountInfoRequestBuilder<R> = RequestBuilder<
 
 impl<R> DefaultRequestCycles for GetAccountInfoRequestBuilder<R> {
     fn default_request_cycles(&self) -> u128 {
-        10_000_000_000
+        self.default_cycles_for(10_000_000_000)
     }
 }
 
@@ -216,7 +216,7 @@ pub type GetBalanceRequestBuilder<R> = RequestBuilder<
 
 impl<R> DefaultRequestCycles for GetBalanceRequestBuilder<R> {
     fn default_request_cycles(&self) -> u128 {
-        10_000_000_000
+        self.default_cycles_for(10_000_000_000)
     }
 }
 
@@ -283,14 +283,15 @@ pub type GetBlockRequestBuilder<R> = RequestBuilder<
 
 impl<R> DefaultRequestCycles for GetBlockRequestBuilder<R> {
     fn default_request_cycles(&self) -> u128 {
-        match self.request.params.transaction_details.unwrap_or_default() {
+        let per_provider = match self.request.params.transaction_details.unwrap_or_default() {
             TransactionDetails::Accounts => 1_000_000_000_000,
             TransactionDetails::Signatures => 100_000_000_000,
             TransactionDetails::None => match self.request.params.rewards {
                 Some(true) | None => 20_000_000_000,
                 Some(false) => 10_000_000_000,
             },
-        }
+        };
+        self.default_cycles_for(per_provider)
     }
 }
 
@@ -379,7 +380,8 @@ pub type GetSignaturesForAddressRequestBuilder<R> = RequestBuilder<
 
 impl<R> DefaultRequestCycles for GetSignaturesForAddressRequestBuilder<R> {
     fn default_request_cycles(&self) -> u128 {
-        2_000_000_000 // TODO XC-338: Check heuristic
+        // TODO XC-338: Check heuristic
+        self.default_cycles_for(2_000_000_000)
     }
 }
 
@@ -445,7 +447,9 @@ pub type GetSignatureStatusesRequestBuilder<R> = RequestBuilder<
 impl<R> DefaultRequestCycles for GetSignatureStatusesRequestBuilder<R> {
     fn default_request_cycles(&self) -> u128 {
         // TODO XC-338: Check heuristic
-        2_000_000_000 + self.request.params.signatures.len() as u128 * 1_000_000
+        let per_provider =
+            2_000_000_000 + self.request.params.signatures.len() as u128 * 1_000_000;
+        self.default_cycles_for(per_provider)
     }
 }
 
@@ -496,7 +500,7 @@ pub type GetSlotRequestBuilder<R> = RequestBuilder<
 
 impl<R> DefaultRequestCycles for GetSlotRequestBuilder<R> {
     fn default_request_cycles(&self) -> u128 {
-        10_000_000_000
+        self.default_cycles_for(10_000_000_000)
     }
 }
 
@@ -550,7 +554,7 @@ pub type GetTokenAccountBalanceRequestBuilder<R> = RequestBuilder<
 
 impl<R> DefaultRequestCycles for GetTokenAccountBalanceRequestBuilder<R> {
     fn default_request_cycles(&self) -> u128 {
-        10_000_000_000
+        self.default_cycles_for(10_000_000_000)
     }
 }
 
@@ -602,7 +606,7 @@ pub type GetTransactionRequestBuilder<R> = RequestBuilder<
 
 impl<R> DefaultRequestCycles for GetTransactionRequestBuilder<R> {
     fn default_request_cycles(&self) -> u128 {
-        10_000_000_000
+        self.default_cycles_for(10_000_000_000)
     }
 }
 
@@ -662,7 +666,7 @@ pub type SendTransactionRequestBuilder<R> = RequestBuilder<
 
 impl<R> DefaultRequestCycles for SendTransactionRequestBuilder<R> {
     fn default_request_cycles(&self) -> u128 {
-        10_000_000_000
+        self.default_cycles_for(10_000_000_000)
     }
 }
 
@@ -724,7 +728,7 @@ pub type JsonRequestBuilder<R> =
 
 impl<R> DefaultRequestCycles for JsonRequestBuilder<R> {
     fn default_request_cycles(&self) -> u128 {
-        10_000_000_000
+        self.default_cycles_for(10_000_000_000)
     }
 }
 
@@ -747,7 +751,7 @@ pub type GetRecentPrioritizationFeesRequestBuilder<R> = RequestBuilder<
 
 impl<R> DefaultRequestCycles for GetRecentPrioritizationFeesRequestBuilder<R> {
     fn default_request_cycles(&self) -> u128 {
-        10_000_000_000
+        self.default_cycles_for(10_000_000_000)
     }
 }
 
@@ -852,6 +856,9 @@ pub trait SolRpcConfig {
 
     /// Return a new RPC config with the given response consensys.
     fn with_response_consensus(self, response_consensus: ConsensusStrategy) -> Self;
+
+    /// Return the response consensus strategy, if set.
+    fn response_consensus(&self) -> Option<&ConsensusStrategy>;
 }
 
 impl SolRpcConfig for RpcConfig {
@@ -867,6 +874,10 @@ impl SolRpcConfig for RpcConfig {
             response_consensus: Some(response_consensus),
             ..self
         }
+    }
+
+    fn response_consensus(&self) -> Option<&ConsensusStrategy> {
+        self.response_consensus.as_ref()
     }
 }
 
@@ -884,6 +895,10 @@ impl SolRpcConfig for GetSlotRpcConfig {
             ..self
         }
     }
+
+    fn response_consensus(&self) -> Option<&ConsensusStrategy> {
+        self.response_consensus.as_ref()
+    }
 }
 
 impl SolRpcConfig for GetRecentPrioritizationFeesRpcConfig {
@@ -895,6 +910,37 @@ impl SolRpcConfig for GetRecentPrioritizationFeesRpcConfig {
     fn with_response_consensus(mut self, response_consensus: ConsensusStrategy) -> Self {
         self.set_response_consensus(response_consensus);
         self
+    }
+
+    fn response_consensus(&self) -> Option<&ConsensusStrategy> {
+        self.response_consensus.as_ref()
+    }
+}
+
+impl<Runtime, Config: SolRpcConfig, Params, CandidOutput, Output>
+    RequestBuilder<Runtime, Config, Params, CandidOutput, Output>
+{
+    /// Return the number of providers that will be queried for this request.
+    fn num_providers(&self) -> u32 {
+        /// Default number of providers queried when using `ConsensusStrategy::Equality`.
+        const DEFAULT_NUM_PROVIDERS: u32 = 3;
+
+        match &self.request.rpc_sources {
+            RpcSources::Custom(providers) => providers.len() as u32,
+            RpcSources::Default(_) => {
+                match self.request.rpc_config.as_ref().and_then(|c| c.response_consensus()) {
+                    Some(ConsensusStrategy::Threshold {
+                        total: Some(total), ..
+                    }) => *total as u32,
+                    _ => DEFAULT_NUM_PROVIDERS,
+                }
+            }
+        }
+    }
+
+    /// Return the default cycles for this request, given the per-provider base cycles.
+    fn default_cycles_for(&self, per_provider_cycles: u128) -> u128 {
+        per_provider_cycles.saturating_mul(self.num_providers() as u128)
     }
 }
 

--- a/libs/client/src/request/mod.rs
+++ b/libs/client/src/request/mod.rs
@@ -112,7 +112,7 @@ pub trait DefaultRequestCycles {
     ///
     /// This value is multiplied by the number of providers before sending the request,
     /// and only used if the user did not set a number of cycles to attach.
-    fn default_cycles_per_provider(&self) -> u128;
+    fn default_request_cycles(&self) -> u128;
 }
 
 #[derive(Debug, Clone)]
@@ -150,7 +150,7 @@ pub type GetAccountInfoRequestBuilder<R> = RequestBuilder<
 >;
 
 impl<R> DefaultRequestCycles for GetAccountInfoRequestBuilder<R> {
-    fn default_cycles_per_provider(&self) -> u128 {
+    fn default_request_cycles(&self) -> u128 {
         10_000_000_000
     }
 }
@@ -216,7 +216,7 @@ pub type GetBalanceRequestBuilder<R> = RequestBuilder<
 >;
 
 impl<R> DefaultRequestCycles for GetBalanceRequestBuilder<R> {
-    fn default_cycles_per_provider(&self) -> u128 {
+    fn default_request_cycles(&self) -> u128 {
         10_000_000_000
     }
 }
@@ -283,7 +283,7 @@ pub type GetBlockRequestBuilder<R> = RequestBuilder<
 >;
 
 impl<R> DefaultRequestCycles for GetBlockRequestBuilder<R> {
-    fn default_cycles_per_provider(&self) -> u128 {
+    fn default_request_cycles(&self) -> u128 {
         match self.request.params.transaction_details.unwrap_or_default() {
             TransactionDetails::Accounts => 1_000_000_000_000,
             TransactionDetails::Signatures => 100_000_000_000,
@@ -379,8 +379,7 @@ pub type GetSignaturesForAddressRequestBuilder<R> = RequestBuilder<
 >;
 
 impl<R> DefaultRequestCycles for GetSignaturesForAddressRequestBuilder<R> {
-    fn default_cycles_per_provider(&self) -> u128 {
-        // TODO XC-338: Check heuristic
+    fn default_request_cycles(&self) -> u128 {
         2_000_000_000
     }
 }
@@ -445,8 +444,7 @@ pub type GetSignatureStatusesRequestBuilder<R> = RequestBuilder<
 >;
 
 impl<R> DefaultRequestCycles for GetSignatureStatusesRequestBuilder<R> {
-    fn default_cycles_per_provider(&self) -> u128 {
-        // TODO XC-338: Check heuristic
+    fn default_request_cycles(&self) -> u128 {
         2_000_000_000 + self.request.params.signatures.len() as u128 * 1_000_000
     }
 }
@@ -497,7 +495,7 @@ pub type GetSlotRequestBuilder<R> = RequestBuilder<
 >;
 
 impl<R> DefaultRequestCycles for GetSlotRequestBuilder<R> {
-    fn default_cycles_per_provider(&self) -> u128 {
+    fn default_request_cycles(&self) -> u128 {
         10_000_000_000
     }
 }
@@ -551,7 +549,7 @@ pub type GetTokenAccountBalanceRequestBuilder<R> = RequestBuilder<
 >;
 
 impl<R> DefaultRequestCycles for GetTokenAccountBalanceRequestBuilder<R> {
-    fn default_cycles_per_provider(&self) -> u128 {
+    fn default_request_cycles(&self) -> u128 {
         10_000_000_000
     }
 }
@@ -603,7 +601,7 @@ pub type GetTransactionRequestBuilder<R> = RequestBuilder<
 >;
 
 impl<R> DefaultRequestCycles for GetTransactionRequestBuilder<R> {
-    fn default_cycles_per_provider(&self) -> u128 {
+    fn default_request_cycles(&self) -> u128 {
         10_000_000_000
     }
 }
@@ -663,7 +661,7 @@ pub type SendTransactionRequestBuilder<R> = RequestBuilder<
 >;
 
 impl<R> DefaultRequestCycles for SendTransactionRequestBuilder<R> {
-    fn default_cycles_per_provider(&self) -> u128 {
+    fn default_request_cycles(&self) -> u128 {
         10_000_000_000
     }
 }
@@ -725,7 +723,7 @@ pub type JsonRequestBuilder<R> =
     RequestBuilder<R, RpcConfig, String, MultiRpcResult<String>, MultiRpcResult<String>>;
 
 impl<R> DefaultRequestCycles for JsonRequestBuilder<R> {
-    fn default_cycles_per_provider(&self) -> u128 {
+    fn default_request_cycles(&self) -> u128 {
         10_000_000_000
     }
 }
@@ -748,7 +746,7 @@ pub type GetRecentPrioritizationFeesRequestBuilder<R> = RequestBuilder<
 >;
 
 impl<R> DefaultRequestCycles for GetRecentPrioritizationFeesRequestBuilder<R> {
-    fn default_cycles_per_provider(&self) -> u128 {
+    fn default_request_cycles(&self) -> u128 {
         10_000_000_000
     }
 }
@@ -926,7 +924,12 @@ impl<Runtime, Config: SolRpcConfig, Params, CandidOutput, Output>
         match &self.request.rpc_sources {
             RpcSources::Custom(providers) => providers.len() as u32,
             RpcSources::Default(_) => {
-                match self.request.rpc_config.as_ref().and_then(|c| c.response_consensus()) {
+                match self
+                    .request
+                    .rpc_config
+                    .as_ref()
+                    .and_then(|c| c.response_consensus())
+                {
                     Some(ConsensusStrategy::Threshold {
                         total: Some(total), ..
                     }) => *total as u32,
@@ -935,7 +938,6 @@ impl<Runtime, Config: SolRpcConfig, Params, CandidOutput, Output>
             }
         }
     }
-
 }
 
 impl<Runtime, Config: SolRpcConfig + Default, Params, CandidOutput, Output>
@@ -995,7 +997,7 @@ impl<R: Runtime, Config, Params, CandidOutput, Output>
         RequestBuilder<R, Config, Params, CandidOutput, Output>: DefaultRequestCycles,
     {
         let cycles = self.request.cycles.unwrap_or_else(|| {
-            self.default_cycles_per_provider()
+            self.default_request_cycles()
                 .saturating_mul(self.num_providers() as u128)
         });
         self.client

--- a/libs/client/src/request/mod.rs
+++ b/libs/client/src/request/mod.rs
@@ -380,7 +380,7 @@ pub type GetSignaturesForAddressRequestBuilder<R> = RequestBuilder<
 
 impl<R> DefaultRequestCycles for GetSignaturesForAddressRequestBuilder<R> {
     fn default_request_cycles(&self) -> u128 {
-        2_000_000_000
+        10_000_000_000
     }
 }
 

--- a/libs/client/src/request/mod.rs
+++ b/libs/client/src/request/mod.rs
@@ -106,12 +106,13 @@ impl SolRpcEndpoint {
     }
 }
 
-/// Specifies the default number of cycles attached with a request if it was not set.
+/// Specifies the default number of cycles per provider attached with a request if it was not set.
 pub trait DefaultRequestCycles {
-    /// The default number of cycles to attach with this request.
+    /// The default number of cycles per provider to attach with this request.
     ///
-    /// This method will be called just before sending the request and only if the user did not set a number of cycles to attach.
-    fn default_request_cycles(&self) -> u128;
+    /// This value is multiplied by the number of providers before sending the request,
+    /// and only used if the user did not set a number of cycles to attach.
+    fn default_cycles_per_provider(&self) -> u128;
 }
 
 #[derive(Debug, Clone)]
@@ -149,8 +150,8 @@ pub type GetAccountInfoRequestBuilder<R> = RequestBuilder<
 >;
 
 impl<R> DefaultRequestCycles for GetAccountInfoRequestBuilder<R> {
-    fn default_request_cycles(&self) -> u128 {
-        self.default_cycles_for(10_000_000_000)
+    fn default_cycles_per_provider(&self) -> u128 {
+        10_000_000_000
     }
 }
 
@@ -215,8 +216,8 @@ pub type GetBalanceRequestBuilder<R> = RequestBuilder<
 >;
 
 impl<R> DefaultRequestCycles for GetBalanceRequestBuilder<R> {
-    fn default_request_cycles(&self) -> u128 {
-        self.default_cycles_for(10_000_000_000)
+    fn default_cycles_per_provider(&self) -> u128 {
+        10_000_000_000
     }
 }
 
@@ -282,16 +283,15 @@ pub type GetBlockRequestBuilder<R> = RequestBuilder<
 >;
 
 impl<R> DefaultRequestCycles for GetBlockRequestBuilder<R> {
-    fn default_request_cycles(&self) -> u128 {
-        let per_provider = match self.request.params.transaction_details.unwrap_or_default() {
+    fn default_cycles_per_provider(&self) -> u128 {
+        match self.request.params.transaction_details.unwrap_or_default() {
             TransactionDetails::Accounts => 1_000_000_000_000,
             TransactionDetails::Signatures => 100_000_000_000,
             TransactionDetails::None => match self.request.params.rewards {
                 Some(true) | None => 20_000_000_000,
                 Some(false) => 10_000_000_000,
             },
-        };
-        self.default_cycles_for(per_provider)
+        }
     }
 }
 
@@ -379,9 +379,9 @@ pub type GetSignaturesForAddressRequestBuilder<R> = RequestBuilder<
 >;
 
 impl<R> DefaultRequestCycles for GetSignaturesForAddressRequestBuilder<R> {
-    fn default_request_cycles(&self) -> u128 {
+    fn default_cycles_per_provider(&self) -> u128 {
         // TODO XC-338: Check heuristic
-        self.default_cycles_for(2_000_000_000)
+        2_000_000_000
     }
 }
 
@@ -445,11 +445,9 @@ pub type GetSignatureStatusesRequestBuilder<R> = RequestBuilder<
 >;
 
 impl<R> DefaultRequestCycles for GetSignatureStatusesRequestBuilder<R> {
-    fn default_request_cycles(&self) -> u128 {
+    fn default_cycles_per_provider(&self) -> u128 {
         // TODO XC-338: Check heuristic
-        let per_provider =
-            2_000_000_000 + self.request.params.signatures.len() as u128 * 1_000_000;
-        self.default_cycles_for(per_provider)
+        2_000_000_000 + self.request.params.signatures.len() as u128 * 1_000_000
     }
 }
 
@@ -499,8 +497,8 @@ pub type GetSlotRequestBuilder<R> = RequestBuilder<
 >;
 
 impl<R> DefaultRequestCycles for GetSlotRequestBuilder<R> {
-    fn default_request_cycles(&self) -> u128 {
-        self.default_cycles_for(10_000_000_000)
+    fn default_cycles_per_provider(&self) -> u128 {
+        10_000_000_000
     }
 }
 
@@ -553,8 +551,8 @@ pub type GetTokenAccountBalanceRequestBuilder<R> = RequestBuilder<
 >;
 
 impl<R> DefaultRequestCycles for GetTokenAccountBalanceRequestBuilder<R> {
-    fn default_request_cycles(&self) -> u128 {
-        self.default_cycles_for(10_000_000_000)
+    fn default_cycles_per_provider(&self) -> u128 {
+        10_000_000_000
     }
 }
 
@@ -605,8 +603,8 @@ pub type GetTransactionRequestBuilder<R> = RequestBuilder<
 >;
 
 impl<R> DefaultRequestCycles for GetTransactionRequestBuilder<R> {
-    fn default_request_cycles(&self) -> u128 {
-        self.default_cycles_for(10_000_000_000)
+    fn default_cycles_per_provider(&self) -> u128 {
+        10_000_000_000
     }
 }
 
@@ -665,8 +663,8 @@ pub type SendTransactionRequestBuilder<R> = RequestBuilder<
 >;
 
 impl<R> DefaultRequestCycles for SendTransactionRequestBuilder<R> {
-    fn default_request_cycles(&self) -> u128 {
-        self.default_cycles_for(10_000_000_000)
+    fn default_cycles_per_provider(&self) -> u128 {
+        10_000_000_000
     }
 }
 
@@ -727,8 +725,8 @@ pub type JsonRequestBuilder<R> =
     RequestBuilder<R, RpcConfig, String, MultiRpcResult<String>, MultiRpcResult<String>>;
 
 impl<R> DefaultRequestCycles for JsonRequestBuilder<R> {
-    fn default_request_cycles(&self) -> u128 {
-        self.default_cycles_for(10_000_000_000)
+    fn default_cycles_per_provider(&self) -> u128 {
+        10_000_000_000
     }
 }
 
@@ -750,8 +748,8 @@ pub type GetRecentPrioritizationFeesRequestBuilder<R> = RequestBuilder<
 >;
 
 impl<R> DefaultRequestCycles for GetRecentPrioritizationFeesRequestBuilder<R> {
-    fn default_request_cycles(&self) -> u128 {
-        self.default_cycles_for(10_000_000_000)
+    fn default_cycles_per_provider(&self) -> u128 {
+        10_000_000_000
     }
 }
 
@@ -921,7 +919,7 @@ impl<Runtime, Config: SolRpcConfig, Params, CandidOutput, Output>
     RequestBuilder<Runtime, Config, Params, CandidOutput, Output>
 {
     /// Return the number of providers that will be queried for this request.
-    fn num_providers(&self) -> u32 {
+    pub(crate) fn num_providers(&self) -> u32 {
         /// Default number of providers queried when using default RPC sources.
         const DEFAULT_NUM_PROVIDERS: u32 = 3;
 
@@ -938,10 +936,6 @@ impl<Runtime, Config: SolRpcConfig, Params, CandidOutput, Output>
         }
     }
 
-    /// Return the default cycles for this request, given the per-provider base cycles.
-    fn default_cycles_for(&self, per_provider_cycles: u128) -> u128 {
-        per_provider_cycles.saturating_mul(self.num_providers() as u128)
-    }
 }
 
 impl<Runtime, Config: SolRpcConfig + Default, Params, CandidOutput, Output>
@@ -980,7 +974,7 @@ impl<R: Runtime, Config, Params, CandidOutput, Output>
     /// If the request was not successful.
     pub async fn send(self) -> Output
     where
-        Config: CandidType + Send,
+        Config: CandidType + Send + SolRpcConfig,
         Params: CandidType + Send,
         CandidOutput: Into<Output> + CandidType + DeserializeOwned,
         RequestBuilder<R, Config, Params, CandidOutput, Output>: DefaultRequestCycles,
@@ -995,15 +989,15 @@ impl<R: Runtime, Config, Params, CandidOutput, Output>
     /// either the request response or any error that occurs while sending the request.
     pub async fn try_send(self) -> Result<Output, IcError>
     where
-        Config: CandidType + Send,
+        Config: CandidType + Send + SolRpcConfig,
         Params: CandidType + Send,
         CandidOutput: Into<Output> + CandidType + DeserializeOwned,
         RequestBuilder<R, Config, Params, CandidOutput, Output>: DefaultRequestCycles,
     {
-        let cycles = self
-            .request
-            .cycles
-            .unwrap_or_else(|| self.default_request_cycles());
+        let cycles = self.request.cycles.unwrap_or_else(|| {
+            self.default_cycles_per_provider()
+                .saturating_mul(self.num_providers() as u128)
+        });
         self.client
             .try_execute_request::<Config, Params, CandidOutput, Output>(self.request, cycles)
             .await

--- a/libs/client/src/request/mod.rs
+++ b/libs/client/src/request/mod.rs
@@ -922,7 +922,7 @@ impl<Runtime, Config: SolRpcConfig, Params, CandidOutput, Output>
 {
     /// Return the number of providers that will be queried for this request.
     fn num_providers(&self) -> u32 {
-        /// Default number of providers queried when using `ConsensusStrategy::Equality`.
+        /// Default number of providers queried when using default RPC sources.
         const DEFAULT_NUM_PROVIDERS: u32 = 3;
 
         match &self.request.rpc_sources {

--- a/libs/client/src/request/tests.rs
+++ b/libs/client/src/request/tests.rs
@@ -8,9 +8,7 @@ use sol_rpc_types::{
     GetTransactionEncoding, GetTransactionParams, RpcConfig, RpcSources, SendTransactionEncoding,
     SendTransactionParams, Slot, SupportedRpcProviderId, TransactionDetails,
 };
-use sol_rpc_types::{
-    ConfirmedBlock, Hash, MultiRpcResult, RpcError, RpcSource,
-};
+use sol_rpc_types::{ConfirmedBlock, Hash, MultiRpcResult, RpcError, RpcSource};
 use solana_pubkey::{pubkey, Pubkey};
 use solana_signature::Signature;
 use std::{fmt::Debug, num::NonZeroUsize, str::FromStr};
@@ -497,6 +495,59 @@ mod get_recent_block {
     }
 }
 
+mod num_providers_tests {
+    use super::*;
+
+    #[test]
+    fn should_default_to_3_for_default_sources() {
+        let client = SolRpcClient::builder_for_ic().build();
+        let builder = client.get_balance(PUBKEY);
+        assert_eq!(builder.num_providers(), 3);
+    }
+
+    #[test]
+    fn should_count_single_custom_provider() {
+        let client = SolRpcClient::builder_for_ic()
+            .with_rpc_sources(RpcSources::Custom(vec![RpcSource::Supported(
+                SupportedRpcProviderId::AlchemyMainnet,
+            )]))
+            .build();
+        let builder = client.get_balance(PUBKEY);
+        assert_eq!(builder.num_providers(), 1);
+    }
+
+    #[test]
+    fn should_use_custom_provider_count() {
+        let providers = vec![
+            RpcSource::Supported(SupportedRpcProviderId::AlchemyMainnet),
+            RpcSource::Supported(SupportedRpcProviderId::HeliusMainnet),
+            RpcSource::Supported(SupportedRpcProviderId::AnkrMainnet),
+            RpcSource::Supported(SupportedRpcProviderId::DrpcMainnet),
+            RpcSource::Supported(SupportedRpcProviderId::PublicNodeMainnet),
+        ];
+        let client = SolRpcClient::builder_for_ic()
+            .with_rpc_sources(RpcSources::Custom(providers))
+            .build();
+        let builder = client.get_balance(PUBKEY);
+        assert_eq!(builder.num_providers(), 5);
+    }
+
+    #[test]
+    fn should_use_threshold_total() {
+        let client = SolRpcClient::builder_for_ic()
+            .with_rpc_config(RpcConfig {
+                response_size_estimate: None,
+                response_consensus: Some(ConsensusStrategy::Threshold {
+                    total: Some(5),
+                    min: 3,
+                }),
+            })
+            .build();
+        let builder = client.get_balance(PUBKEY);
+        assert_eq!(builder.num_providers(), 5);
+    }
+}
+
 fn assert_params_eq<Runtime, Config, Params, CandidOutput, Output>(
     left: RequestBuilder<Runtime, Config, Params, CandidOutput, Output>,
     right: RequestBuilder<Runtime, Config, Params, CandidOutput, Output>,
@@ -543,103 +594,5 @@ fn block() -> ConfirmedBlock {
         rewards: None,
         num_reward_partitions: None,
         transactions: None,
-    }
-}
-
-mod default_cycles_per_provider {
-    use super::*;
-
-    #[test]
-    fn should_return_per_provider_cycles_for_get_balance() {
-        let client = SolRpcClient::builder_for_ic().build();
-        let builder = client.get_balance(PUBKEY);
-        assert_eq!(builder.default_cycles_per_provider(), 10_000_000_000);
-    }
-
-    #[test]
-    fn should_return_per_provider_cycles_for_get_block_without_transactions() {
-        let client = SolRpcClient::builder_for_ic().build();
-        let builder = client
-            .get_block(123)
-            .with_transaction_details(TransactionDetails::None)
-            .without_rewards();
-        assert_eq!(builder.default_cycles_per_provider(), 10_000_000_000);
-    }
-
-    #[test]
-    fn should_return_per_provider_cycles_for_get_block_with_signature_transactions() {
-        let client = SolRpcClient::builder_for_ic().build();
-        let builder = client
-            .get_block(123)
-            .with_transaction_details(TransactionDetails::Signatures);
-        assert_eq!(builder.default_cycles_per_provider(), 100_000_000_000);
-    }
-
-    #[test]
-    fn should_return_per_provider_cycles_for_get_block_with_account_transactions() {
-        let client = SolRpcClient::builder_for_ic().build();
-        let builder = client
-            .get_block(123)
-            .with_transaction_details(TransactionDetails::Accounts);
-        assert_eq!(builder.default_cycles_per_provider(), 1_000_000_000_000);
-    }
-}
-
-mod num_providers {
-    use super::*;
-
-    #[test]
-    fn should_default_to_3_for_default_sources() {
-        let client = SolRpcClient::builder_for_ic().build();
-        let builder = client.get_balance(PUBKEY);
-        assert_eq!(builder.num_providers(), 3);
-    }
-
-    #[test]
-    fn should_use_custom_provider_count() {
-        let providers = vec![
-            RpcSource::Supported(SupportedRpcProviderId::AlchemyMainnet),
-            RpcSource::Supported(SupportedRpcProviderId::HeliusMainnet),
-            RpcSource::Supported(SupportedRpcProviderId::AnkrMainnet),
-            RpcSource::Supported(SupportedRpcProviderId::DrpcMainnet),
-            RpcSource::Supported(SupportedRpcProviderId::PublicNodeMainnet),
-        ];
-        let client = SolRpcClient::builder_for_ic()
-            .with_rpc_sources(RpcSources::Custom(providers))
-            .build();
-        let builder = client.get_balance(PUBKEY);
-        assert_eq!(builder.num_providers(), 5);
-    }
-
-    #[test]
-    fn should_use_threshold_total() {
-        let client = SolRpcClient::builder_for_ic()
-            .with_rpc_config(RpcConfig {
-                response_size_estimate: None,
-                response_consensus: Some(ConsensusStrategy::Threshold { total: Some(5), min: 3 }),
-            })
-            .build();
-        let builder = client.get_balance(PUBKEY);
-        assert_eq!(builder.num_providers(), 5);
-    }
-
-    #[test]
-    fn should_use_per_request_consensus() {
-        let client = SolRpcClient::builder_for_ic().build();
-        let builder = client
-            .get_balance(PUBKEY)
-            .with_response_consensus(ConsensusStrategy::Threshold { total: Some(4), min: 2 });
-        assert_eq!(builder.num_providers(), 4);
-    }
-
-    #[test]
-    fn should_count_single_custom_provider() {
-        let client = SolRpcClient::builder_for_ic()
-            .with_rpc_sources(RpcSources::Custom(vec![RpcSource::Supported(
-                SupportedRpcProviderId::AlchemyMainnet,
-            )]))
-            .build();
-        let builder = client.get_balance(PUBKEY);
-        assert_eq!(builder.num_providers(), 1);
     }
 }

--- a/libs/client/src/request/tests.rs
+++ b/libs/client/src/request/tests.rs
@@ -546,19 +546,57 @@ fn block() -> ConfirmedBlock {
     }
 }
 
-mod default_request_cycles {
+mod default_cycles_per_provider {
     use super::*;
 
     #[test]
-    fn should_scale_with_default_providers() {
+    fn should_return_per_provider_cycles_for_get_balance() {
         let client = SolRpcClient::builder_for_ic().build();
         let builder = client.get_balance(PUBKEY);
-        // Default is 3 providers (Equality), so 10B * 3 = 30B
-        assert_eq!(builder.default_request_cycles(), 30_000_000_000);
+        assert_eq!(builder.default_cycles_per_provider(), 10_000_000_000);
     }
 
     #[test]
-    fn should_scale_with_custom_providers() {
+    fn should_return_per_provider_cycles_for_get_block_without_transactions() {
+        let client = SolRpcClient::builder_for_ic().build();
+        let builder = client
+            .get_block(123)
+            .with_transaction_details(TransactionDetails::None)
+            .without_rewards();
+        assert_eq!(builder.default_cycles_per_provider(), 10_000_000_000);
+    }
+
+    #[test]
+    fn should_return_per_provider_cycles_for_get_block_with_signature_transactions() {
+        let client = SolRpcClient::builder_for_ic().build();
+        let builder = client
+            .get_block(123)
+            .with_transaction_details(TransactionDetails::Signatures);
+        assert_eq!(builder.default_cycles_per_provider(), 100_000_000_000);
+    }
+
+    #[test]
+    fn should_return_per_provider_cycles_for_get_block_with_account_transactions() {
+        let client = SolRpcClient::builder_for_ic().build();
+        let builder = client
+            .get_block(123)
+            .with_transaction_details(TransactionDetails::Accounts);
+        assert_eq!(builder.default_cycles_per_provider(), 1_000_000_000_000);
+    }
+}
+
+mod num_providers {
+    use super::*;
+
+    #[test]
+    fn should_default_to_3_for_default_sources() {
+        let client = SolRpcClient::builder_for_ic().build();
+        let builder = client.get_balance(PUBKEY);
+        assert_eq!(builder.num_providers(), 3);
+    }
+
+    #[test]
+    fn should_use_custom_provider_count() {
         let providers = vec![
             RpcSource::Supported(SupportedRpcProviderId::AlchemyMainnet),
             RpcSource::Supported(SupportedRpcProviderId::HeliusMainnet),
@@ -570,12 +608,11 @@ mod default_request_cycles {
             .with_rpc_sources(RpcSources::Custom(providers))
             .build();
         let builder = client.get_balance(PUBKEY);
-        // 5 custom providers, so 10B * 5 = 50B
-        assert_eq!(builder.default_request_cycles(), 50_000_000_000);
+        assert_eq!(builder.num_providers(), 5);
     }
 
     #[test]
-    fn should_scale_with_threshold_consensus() {
+    fn should_use_threshold_total() {
         let client = SolRpcClient::builder_for_ic()
             .with_rpc_config(RpcConfig {
                 response_size_estimate: None,
@@ -583,45 +620,26 @@ mod default_request_cycles {
             })
             .build();
         let builder = client.get_balance(PUBKEY);
-        // Threshold with total=5, so 10B * 5 = 50B
-        assert_eq!(builder.default_request_cycles(), 50_000_000_000);
+        assert_eq!(builder.num_providers(), 5);
     }
 
     #[test]
-    fn should_scale_with_single_custom_provider() {
+    fn should_use_per_request_consensus() {
+        let client = SolRpcClient::builder_for_ic().build();
+        let builder = client
+            .get_balance(PUBKEY)
+            .with_response_consensus(ConsensusStrategy::Threshold { total: Some(4), min: 2 });
+        assert_eq!(builder.num_providers(), 4);
+    }
+
+    #[test]
+    fn should_count_single_custom_provider() {
         let client = SolRpcClient::builder_for_ic()
             .with_rpc_sources(RpcSources::Custom(vec![RpcSource::Supported(
                 SupportedRpcProviderId::AlchemyMainnet,
             )]))
             .build();
         let builder = client.get_balance(PUBKEY);
-        // 1 provider, so 10B * 1 = 10B
-        assert_eq!(builder.default_request_cycles(), 10_000_000_000);
-    }
-
-    #[test]
-    fn should_scale_get_block_with_providers() {
-        let client = SolRpcClient::builder_for_ic()
-            .with_rpc_sources(RpcSources::Custom(vec![
-                RpcSource::Supported(SupportedRpcProviderId::AlchemyMainnet),
-                RpcSource::Supported(SupportedRpcProviderId::HeliusMainnet),
-            ]))
-            .build();
-        let builder = client
-            .get_block(123)
-            .with_transaction_details(TransactionDetails::None)
-            .without_rewards();
-        // 2 providers, TransactionDetails::None + no rewards = 10B per provider, so 10B * 2 = 20B
-        assert_eq!(builder.default_request_cycles(), 20_000_000_000);
-    }
-
-    #[test]
-    fn should_use_per_request_consensus_over_client_default() {
-        let client = SolRpcClient::builder_for_ic().build();
-        let builder = client
-            .get_balance(PUBKEY)
-            .with_response_consensus(ConsensusStrategy::Threshold { total: Some(4), min: 2 });
-        // Per-request consensus overrides: 4 providers, so 10B * 4 = 40B
-        assert_eq!(builder.default_request_cycles(), 40_000_000_000);
+        assert_eq!(builder.num_providers(), 1);
     }
 }

--- a/libs/client/src/request/tests.rs
+++ b/libs/client/src/request/tests.rs
@@ -1,14 +1,15 @@
+use crate::request::DefaultRequestCycles;
 use crate::{GetRecentBlockError, RequestBuilder, SolRpcClient, SolRpcEndpoint};
 use serde_json::json;
 use sol_rpc_types::{
-    CommitmentLevel, DataSlice, GetAccountInfoEncoding, GetAccountInfoParams, GetBalanceParams,
-    GetBlockCommitmentLevel, GetBlockParams, GetSignatureStatusesParams,
+    CommitmentLevel, ConsensusStrategy, DataSlice, GetAccountInfoEncoding, GetAccountInfoParams,
+    GetBalanceParams, GetBlockCommitmentLevel, GetBlockParams, GetSignatureStatusesParams,
     GetSignaturesForAddressParams, GetSlotParams, GetTokenAccountBalanceParams,
-    GetTransactionEncoding, GetTransactionParams, SendTransactionEncoding, SendTransactionParams,
-    Slot, TransactionDetails,
+    GetTransactionEncoding, GetTransactionParams, RpcConfig, RpcSources, SendTransactionEncoding,
+    SendTransactionParams, Slot, SupportedRpcProviderId, TransactionDetails,
 };
 use sol_rpc_types::{
-    ConfirmedBlock, Hash, MultiRpcResult, RpcError, RpcSource, SupportedRpcProviderId,
+    ConfirmedBlock, Hash, MultiRpcResult, RpcError, RpcSource,
 };
 use solana_pubkey::{pubkey, Pubkey};
 use solana_signature::Signature;
@@ -542,5 +543,85 @@ fn block() -> ConfirmedBlock {
         rewards: None,
         num_reward_partitions: None,
         transactions: None,
+    }
+}
+
+mod default_request_cycles {
+    use super::*;
+
+    #[test]
+    fn should_scale_with_default_providers() {
+        let client = SolRpcClient::builder_for_ic().build();
+        let builder = client.get_balance(PUBKEY);
+        // Default is 3 providers (Equality), so 10B * 3 = 30B
+        assert_eq!(builder.default_request_cycles(), 30_000_000_000);
+    }
+
+    #[test]
+    fn should_scale_with_custom_providers() {
+        let providers = vec![
+            RpcSource::Supported(SupportedRpcProviderId::AlchemyMainnet),
+            RpcSource::Supported(SupportedRpcProviderId::HeliusMainnet),
+            RpcSource::Supported(SupportedRpcProviderId::AnkrMainnet),
+            RpcSource::Supported(SupportedRpcProviderId::DrpcMainnet),
+            RpcSource::Supported(SupportedRpcProviderId::PublicNodeMainnet),
+        ];
+        let client = SolRpcClient::builder_for_ic()
+            .with_rpc_sources(RpcSources::Custom(providers))
+            .build();
+        let builder = client.get_balance(PUBKEY);
+        // 5 custom providers, so 10B * 5 = 50B
+        assert_eq!(builder.default_request_cycles(), 50_000_000_000);
+    }
+
+    #[test]
+    fn should_scale_with_threshold_consensus() {
+        let client = SolRpcClient::builder_for_ic()
+            .with_rpc_config(RpcConfig {
+                response_size_estimate: None,
+                response_consensus: Some(ConsensusStrategy::Threshold { total: Some(5), min: 3 }),
+            })
+            .build();
+        let builder = client.get_balance(PUBKEY);
+        // Threshold with total=5, so 10B * 5 = 50B
+        assert_eq!(builder.default_request_cycles(), 50_000_000_000);
+    }
+
+    #[test]
+    fn should_scale_with_single_custom_provider() {
+        let client = SolRpcClient::builder_for_ic()
+            .with_rpc_sources(RpcSources::Custom(vec![RpcSource::Supported(
+                SupportedRpcProviderId::AlchemyMainnet,
+            )]))
+            .build();
+        let builder = client.get_balance(PUBKEY);
+        // 1 provider, so 10B * 1 = 10B
+        assert_eq!(builder.default_request_cycles(), 10_000_000_000);
+    }
+
+    #[test]
+    fn should_scale_get_block_with_providers() {
+        let client = SolRpcClient::builder_for_ic()
+            .with_rpc_sources(RpcSources::Custom(vec![
+                RpcSource::Supported(SupportedRpcProviderId::AlchemyMainnet),
+                RpcSource::Supported(SupportedRpcProviderId::HeliusMainnet),
+            ]))
+            .build();
+        let builder = client
+            .get_block(123)
+            .with_transaction_details(TransactionDetails::None)
+            .without_rewards();
+        // 2 providers, TransactionDetails::None + no rewards = 10B per provider, so 10B * 2 = 20B
+        assert_eq!(builder.default_request_cycles(), 20_000_000_000);
+    }
+
+    #[test]
+    fn should_use_per_request_consensus_over_client_default() {
+        let client = SolRpcClient::builder_for_ic().build();
+        let builder = client
+            .get_balance(PUBKEY)
+            .with_response_consensus(ConsensusStrategy::Threshold { total: Some(4), min: 2 });
+        // Per-request consensus overrides: 4 providers, so 10B * 4 = 40B
+        assert_eq!(builder.default_request_cycles(), 40_000_000_000);
     }
 }

--- a/libs/client/src/request/tests.rs
+++ b/libs/client/src/request/tests.rs
@@ -1,4 +1,3 @@
-use crate::request::DefaultRequestCycles;
 use crate::{GetRecentBlockError, RequestBuilder, SolRpcClient, SolRpcEndpoint};
 use serde_json::json;
 use sol_rpc_types::{


### PR DESCRIPTION
## Summary
- `DefaultRequestCycles::default_request_cycles` now specifies per-provider cycle amounts. The total cycles attached are computed as `default_request_cycles() * num_providers()` in `try_send`.
- Adds `num_providers()` on `RequestBuilder` to determine the provider count from `RpcSources::Custom` length, `Threshold { total }`, or the default of 3.
- Adds `response_consensus()` getter to the `SolRpcConfig` trait so the consensus strategy can be inspected from the request builder.
- Increases `getSignaturesForAddress` default from 2B to 10B per provider to match the actual cost.
- Adds an assertion in the integration test `should_get_exact_cycles_cost` verifying that default cycles are sufficient for each endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)