### PR TITLE
ci: pin ic-wasm to 0.9.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,7 @@ jobs:
       - name: 'Install `ic-wasm`'
         uses: taiki-e/install-action@97a5807a604e12de3a13b52d868ebecaeeea757c # v2.75.4
         with:
-          tool: ic-wasm
+          tool: ic-wasm@0.9.10
 
       - name: 'Check canister endpoints'
         run: |


### PR DESCRIPTION
## Summary

Pin `ic-wasm` to a specific version (`0.9.10` — the latest published on crates.io) in the `check-canister-wasm-endpoints` job. Without a version pin, the install resolves to the latest release at CI run time, so a future `ic-wasm` release can silently change the meaning of the check on an unrelated PR.