### PR TITLE
ci: add checks-pass aggregator job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -288,3 +288,52 @@ jobs:
         env:
           DFX_DEPLOY_KEY: ${{ secrets.DFX_DEPLOY_KEY }}
         run: cargo test --locked --package sol_rpc_e2e_tests -- --test-threads 1 --nocapture
+
+  # Single aggregator status check. Configure GitHub branch protection
+  # to require `checks-pass` so that any failing or skipped upstream
+  # job blocks the merge, without having to enumerate every individual
+  # job in the ruleset.
+  checks-pass:
+    # Always run this job!
+    if: always()
+    needs:
+      [
+        lint,
+        check-cargo-lock,
+        cargo-doc,
+        reproducible-build,
+        unit-tests,
+        basic-solana-deployment,
+        check-canister-wasm-endpoints,
+        integration-tests,
+        end-to-end-tests,
+      ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: check lint result
+        if: ${{ needs.lint.result != 'success' }}
+        run: exit 1
+      - name: check check-cargo-lock result
+        if: ${{ needs.check-cargo-lock.result != 'success' }}
+        run: exit 1
+      - name: check cargo-doc result
+        if: ${{ needs.cargo-doc.result != 'success' }}
+        run: exit 1
+      - name: check reproducible-build result
+        if: ${{ needs.reproducible-build.result != 'success' }}
+        run: exit 1
+      - name: check unit-tests result
+        if: ${{ needs.unit-tests.result != 'success' }}
+        run: exit 1
+      - name: check basic-solana-deployment result
+        if: ${{ needs.basic-solana-deployment.result != 'success' }}
+        run: exit 1
+      - name: check check-canister-wasm-endpoints result
+        if: ${{ needs.check-canister-wasm-endpoints.result != 'success' }}
+        run: exit 1
+      - name: check integration-tests result
+        if: ${{ needs.integration-tests.result != 'success' }}
+        run: exit 1
+      - name: check end-to-end-tests result
+        if: ${{ needs.end-to-end-tests.result != 'success' }}
+        run: exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,6 +311,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: |
-          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}" == "true" ]]; then
             exit 1
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -310,30 +310,7 @@ jobs:
       ]
     runs-on: ubuntu-latest
     steps:
-      - name: check lint result
-        if: ${{ needs.lint.result != 'success' }}
-        run: exit 1
-      - name: check check-cargo-lock result
-        if: ${{ needs.check-cargo-lock.result != 'success' }}
-        run: exit 1
-      - name: check cargo-doc result
-        if: ${{ needs.cargo-doc.result != 'success' }}
-        run: exit 1
-      - name: check reproducible-build result
-        if: ${{ needs.reproducible-build.result != 'success' }}
-        run: exit 1
-      - name: check unit-tests result
-        if: ${{ needs.unit-tests.result != 'success' }}
-        run: exit 1
-      - name: check basic-solana-deployment result
-        if: ${{ needs.basic-solana-deployment.result != 'success' }}
-        run: exit 1
-      - name: check check-canister-wasm-endpoints result
-        if: ${{ needs.check-canister-wasm-endpoints.result != 'success' }}
-        run: exit 1
-      - name: check integration-tests result
-        if: ${{ needs.integration-tests.result != 'success' }}
-        run: exit 1
-      - name: check end-to-end-tests result
-        if: ${{ needs.end-to-end-tests.result != 'success' }}
-        run: exit 1
+      - run: |
+          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

Add a single `checks-pass` aggregator status check that depends on every quality-gate job and explicitly fails if any upstream job is non-success (failure, cancelled, or skipped).

This lets GitHub branch protection / rulesets gate merges on a single context name (`checks-pass`) instead of enumerating every individual job. It also future-proofs the protection rule: adding or removing a CI job only needs an update to the `needs:` list here.

Mirrors the pattern already in use in `dfinity/dogecoin-canister` (`.github/workflows/workflow.yml` `checks-pass`).

## Ordering

Should merge **after #321** (the bulk dep revert that fixes `main`). CI on this PR is expected to be red until #321 lands, since `main` itself currently fails on `unit-tests`/`reproducible-build`/`cargo-doc`/etc. The new aggregator simply codifies that "if any of those is red, the merge gate is closed."

## Follow-up (admin action, not in this PR)

After this merges to `main`, an admin should add a `required_status_checks` rule (in `Settings > Rules` or via the org-level rulesets) listing `checks-pass` as a required context. That closes the gap that allowed PRs #311–#318 to merge with red CI and break `main` for ten days.