### PR TITLE
test: de-flake `should_get_recent_prioritization_fees`

### DIFF
--- a/integration_tests/tests/solana_test_validator.rs
+++ b/integration_tests/tests/solana_test_validator.rs
@@ -142,9 +142,10 @@ async fn should_get_recent_prioritization_fees() {
     // The local validator continuously produces new slots (~400ms each) while the
     // SOL and ICP queries run sequentially with HTTP latency between them, so the
     // tail of either response may contain a slot the other side did not observe
-    // yet. Require both sides to be within a single slot of each other, then
-    // compare only on slots present on both — entries above the smaller maximum
-    // are by construction only on one side.
+    // yet. If the ~150-slot sliding window is at capacity, advancing one slot
+    // between queries also shifts the bottom by one. Require both maxima and
+    // both minima to be within a single slot of each other, then compare only
+    // on the slot range present on both sides.
     let sol_max_slot = sol_res
         .iter()
         .map(|f| f.slot)
@@ -155,18 +156,33 @@ async fn should_get_recent_prioritization_fees() {
         .map(|f| f.slot)
         .max()
         .expect("ICP results should not be empty");
+    let sol_min_slot = sol_res
+        .iter()
+        .map(|f| f.slot)
+        .min()
+        .expect("SOL results should not be empty");
+    let ic_min_slot = ic_res
+        .iter()
+        .map(|f| f.slot)
+        .min()
+        .expect("ICP results should not be empty");
     assert!(
         sol_max_slot.abs_diff(ic_max_slot) < 2,
         "SOL max slot ({sol_max_slot}) and ICP max slot ({ic_max_slot}) differ by more than 1 slot"
     );
+    assert!(
+        sol_min_slot.abs_diff(ic_min_slot) < 2,
+        "SOL min slot ({sol_min_slot}) and ICP min slot ({ic_min_slot}) differ by more than 1 slot"
+    );
     let settled_max = sol_max_slot.min(ic_max_slot);
+    let settled_min = sol_min_slot.max(ic_min_slot);
     let sol_res: Vec<_> = sol_res
         .into_iter()
-        .filter(|f| f.slot <= settled_max)
+        .filter(|f| f.slot >= settled_min && f.slot <= settled_max)
         .collect();
     let ic_res: Vec<_> = ic_res
         .into_iter()
-        .filter(|f| f.slot <= settled_max)
+        .filter(|f| f.slot >= settled_min && f.slot <= settled_max)
         .collect();
 
     assert_eq!(

--- a/integration_tests/tests/solana_test_validator.rs
+++ b/integration_tests/tests/solana_test_validator.rs
@@ -78,7 +78,6 @@ async fn should_get_slot() {
 async fn should_get_recent_prioritization_fees() {
     const BASE_FEE_PER_SIGNATURE_LAMPORTS: u64 = 5000;
     const NUM_TRANSACTIONS: u64 = 10;
-    const SLOT_SAFETY_MARGIN: u64 = 5;
 
     let setup = Setup::new().await;
 
@@ -142,22 +141,27 @@ async fn should_get_recent_prioritization_fees() {
 
     // The local validator continuously produces new slots (~400ms each) while the
     // SOL and ICP queries run sequentially with HTTP latency between them, so the
-    // tail of either response may contain slots the other side did not observe yet.
-    // Restrict the comparison to slots that are guaranteed to be settled on both
-    // sides by trimming a safety margin off the smaller maximum slot.
-    let sol_max_slot = sol_res.iter().map(|f| f.slot).max();
-    let ic_max_slot = ic_res.iter().map(|f| f.slot).max();
-    let settled_max = sol_max_slot
-        .zip(ic_max_slot)
-        .map(|(s, i)| s.min(i).saturating_sub(SLOT_SAFETY_MARGIN));
-    let sol_res: Vec<_> = sol_res
-        .into_iter()
-        .filter(|f| settled_max.is_some_and(|m| f.slot <= m))
-        .collect();
-    let ic_res: Vec<_> = ic_res
-        .into_iter()
-        .filter(|f| settled_max.is_some_and(|m| f.slot <= m))
-        .collect();
+    // tail of either response may contain a slot the other side did not observe
+    // yet. Require both sides to be within a single slot of each other, then
+    // compare only on slots present on both — entries above the smaller maximum
+    // are by construction only on one side.
+    let sol_max_slot = sol_res
+        .iter()
+        .map(|f| f.slot)
+        .max()
+        .expect("SOL results should not be empty");
+    let ic_max_slot = ic_res
+        .iter()
+        .map(|f| f.slot)
+        .max()
+        .expect("ICP results should not be empty");
+    assert!(
+        sol_max_slot.abs_diff(ic_max_slot) < 2,
+        "SOL max slot ({sol_max_slot}) and ICP max slot ({ic_max_slot}) differ by more than 1 slot"
+    );
+    let settled_max = sol_max_slot.min(ic_max_slot);
+    let sol_res: Vec<_> = sol_res.into_iter().filter(|f| f.slot <= settled_max).collect();
+    let ic_res: Vec<_> = ic_res.into_iter().filter(|f| f.slot <= settled_max).collect();
 
     assert_eq!(
         sol_res.len(),

--- a/integration_tests/tests/solana_test_validator.rs
+++ b/integration_tests/tests/solana_test_validator.rs
@@ -78,6 +78,7 @@ async fn should_get_slot() {
 async fn should_get_recent_prioritization_fees() {
     const BASE_FEE_PER_SIGNATURE_LAMPORTS: u64 = 5000;
     const NUM_TRANSACTIONS: u64 = 10;
+    const SLOT_SAFETY_MARGIN: u64 = 5;
 
     let setup = Setup::new().await;
 
@@ -138,6 +139,25 @@ async fn should_get_recent_prioritization_fees() {
             },
         )
         .await;
+
+    // The local validator continuously produces new slots (~400ms each) while the
+    // SOL and ICP queries run sequentially with HTTP latency between them, so the
+    // tail of either response may contain slots the other side did not observe yet.
+    // Restrict the comparison to slots that are guaranteed to be settled on both
+    // sides by trimming a safety margin off the smaller maximum slot.
+    let sol_max_slot = sol_res.iter().map(|f| f.slot).max();
+    let ic_max_slot = ic_res.iter().map(|f| f.slot).max();
+    let settled_max = sol_max_slot
+        .zip(ic_max_slot)
+        .map(|(s, i)| s.min(i).saturating_sub(SLOT_SAFETY_MARGIN));
+    let sol_res: Vec<_> = sol_res
+        .into_iter()
+        .filter(|f| settled_max.is_some_and(|m| f.slot <= m))
+        .collect();
+    let ic_res: Vec<_> = ic_res
+        .into_iter()
+        .filter(|f| settled_max.is_some_and(|m| f.slot <= m))
+        .collect();
 
     assert_eq!(
         sol_res.len(),

--- a/integration_tests/tests/solana_test_validator.rs
+++ b/integration_tests/tests/solana_test_validator.rs
@@ -160,8 +160,14 @@ async fn should_get_recent_prioritization_fees() {
         "SOL max slot ({sol_max_slot}) and ICP max slot ({ic_max_slot}) differ by more than 1 slot"
     );
     let settled_max = sol_max_slot.min(ic_max_slot);
-    let sol_res: Vec<_> = sol_res.into_iter().filter(|f| f.slot <= settled_max).collect();
-    let ic_res: Vec<_> = ic_res.into_iter().filter(|f| f.slot <= settled_max).collect();
+    let sol_res: Vec<_> = sol_res
+        .into_iter()
+        .filter(|f| f.slot <= settled_max)
+        .collect();
+    let ic_res: Vec<_> = ic_res
+        .into_iter()
+        .filter(|f| f.slot <= settled_max)
+        .collect();
 
     assert_eq!(
         sol_res.len(),


### PR DESCRIPTION
## Summary

`should_get_recent_prioritization_fees` was flaky because the local validator keeps producing slots (~400ms each) while the SOL and ICP queries run sequentially with HTTP latency between them — so the tail of either response could contain a slot the other side had not yet observed (e.g. [run 25784336927](https://github.com/dfinity/sol-rpc-canister/actions/runs/25784336927/job/75734746660), where SOL stopped at 1020 and ICP had one extra entry at 1021, identical on 614-1020).

The fix requires both maxima and both minima to be within a single slot of each other, then restricts the comparison to the overlapping slot range `[max(sol_min, ic_min), min(sol_max, ic_max)]`. This is symmetric on both edges, so it also covers the case where the ~150-slot sliding window is at capacity and the validator advances one slot between queries (shifting the bottom edge by one). The check still validates that the canister mirrors Solana exactly on the overlapping range; only an intentional, bounded one-slot tail at each edge is ignored.