### PR TITLE
build(deps): batch Cargo bumps (ic-agent, candid, candid_parser, serde_json)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -688,9 +688,9 @@ dependencies = [
 
 [[package]]
 name = "candid_parser"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50e7b872ea5d7b8b445b7b15134ccb7d71e53882c4b5db62e706f9f8a8637c50"
+checksum = "470a4cf0c110e217e54ab3d21c4a9c290736c4a70ab6263d65155522d4b93fb6"
 dependencies = [
  "anyhow",
  "candid",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -653,9 +653,9 @@ dependencies = [
 
 [[package]]
 name = "candid"
-version = "0.10.27"
+version = "0.10.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ba5b4833b63bf7b785fecdd2cc918ed90d988fd974825d5c48e7b407c39ef38"
+checksum = "f8f781afa4a1303e3eab4ada0720a874942bcfa936ce01b816ac6378945c43a9"
 dependencies = [
  "anyhow",
  "binread",
@@ -676,9 +676,9 @@ dependencies = [
 
 [[package]]
 name = "candid_derive"
-version = "0.10.27"
+version = "0.10.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b60664b6324832dfb4863f3b19eb4d58819cd38fba6d3941b101213cea0d9ec"
+checksum = "ad6ae8e7944dd0035651bc0e7b3a3e4cb16f5fc43f8ae4fd76b36ff2cd52759f"
 dependencies = [
  "lazy_static",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4628,9 +4628,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2261,9 +2261,9 @@ dependencies = [
 
 [[package]]
 name = "ic-agent"
-version = "0.47.2"
+version = "0.47.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fefe511d29d927aa5a2090c2e26e0b72cd0633ab7007927e19aeceb05c2a42b1"
+checksum = "85dbab284eac1806b77833cff143d66ae97aae74d34b0e60fb4ab4edf3d6fa12"
 dependencies = [
  "arc-swap",
  "async-channel 2.5.0",
@@ -2284,7 +2284,7 @@ dependencies = [
  "http-body-util",
  "ic-certification",
  "ic-ed25519",
- "ic-transport-types 0.47.2",
+ "ic-transport-types 0.47.3",
  "ic-verify-bls-signature",
  "ic_principal",
  "k256",
@@ -2554,9 +2554,9 @@ dependencies = [
 
 [[package]]
 name = "ic-transport-types"
-version = "0.47.2"
+version = "0.47.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a46a13c1e36d4ac5db68a84e68f2e9edf7773bea131e915e251709b00f5910d9"
+checksum = "a2116182b3ec5a831d579db0a205b6cf9c2ca96616493bef99480532d0b3c2f5"
 dependencies = [
  "candid",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ rand_chacha = { version = "0.10.0", default-features = false }
 regex = "1.12.3"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_bytes = "0.11.19"
-serde_json = "1.0.149"
+serde_json = "1.0.150"
 serde_tuple = "1.1.3"
 serde_with = "3.20.0"
 sol_rpc_client = { version = "6.0.0", path = "libs/client" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ base64 = "0.22.1"
 bincode = "1.3.3"
 bs58 = "0.5.1"
 candid = "0.10.26"
-candid_parser = "0.3.0"
+candid_parser = "0.3.2"
 canhttp = "0.6.0"
 canlog = { version = "0.2.0", features = ["derive"] }
 ciborium = "0.2.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ async-trait = "0.1.89"
 base64 = "0.22.1"
 bincode = "1.3.3"
 bs58 = "0.5.1"
-candid = "0.10.26"
+candid = "0.10.29"
 candid_parser = "0.3.2"
 canhttp = "0.6.0"
 canlog = { version = "0.2.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ futures = "0.3.32"
 getrandom = { version = "*", default-features = false, features = ["custom"] }
 hex = "0.4.3"
 http = "1.4.0"
-ic-agent = "0.47.2"
+ic-agent = "0.47.3"
 ic-agent-canister-runtime = "0.4.0"
 ic-canister-runtime = "0.2.2"
 ic-cdk = "0.20.0"


### PR DESCRIPTION
Combines four Dependabot bumps into a single PR to avoid the rebase cascade:

- `ic-agent` 0.47.2 → 0.47.3 (#336)
- `candid_parser` 0.3.1 → 0.3.2 (#340)
- `candid` 0.10.27 → 0.10.29 (#341, Dependabot retargeted from 0.10.28 to 0.10.29)
- `serde_json` 1.0.149 → 1.0.150 (#343)

Supersedes #336, #340, #341, #343 — they can be closed once this lands.

An empty maintainer commit sits on top so the `pull_request.synchronize` event runs as `gregorydemay`, unblocking `DFX_DEPLOY_KEY` for the e2e job.