### PR TITLE
build(deps): consolidate Dependabot bumps that need no code changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -401,6 +401,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
+
+[[package]]
 name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1633,7 +1639,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4289,7 +4295,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4347,7 +4353,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4368,7 +4374,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4976,7 +4982,7 @@ name = "sol_rpc_int_tests"
 version = "1.0.0"
 dependencies = [
  "assert_matches",
- "base64 0.22.1",
+ "base64 0.23.0",
  "bincode",
  "candid",
  "canhttp",
@@ -5023,7 +5029,7 @@ dependencies = [
 name = "sol_rpc_types"
 version = "3.1.2"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.0",
  "bincode",
  "bs58",
  "candid",
@@ -7177,7 +7183,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7974,7 +7980,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -653,9 +653,9 @@ dependencies = [
 
 [[package]]
 name = "candid"
-version = "0.10.31"
+version = "0.10.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1347fd6b24f5ad23e4ab16d49551a03d396410dcb086e8f969c21efdf4b1dbd8"
+checksum = "b649560badafa98cdf260958393f317c013b5aa819dba26f21cc3e26cae41dae"
 dependencies = [
  "anyhow",
  "binread",
@@ -676,9 +676,9 @@ dependencies = [
 
 [[package]]
 name = "candid_derive"
-version = "0.10.31"
+version = "0.10.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad381629d2d2940899c3a784ccd4fe59e255b5714e7520f016f839f07d2236e7"
+checksum = "8f94f9df97dd04077b5a30e82dfb5a5f2eae1a6e8c9d6a98fd24351c8a333464"
 dependencies = [
  "lazy_static",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ readme = "README.md"
 [workspace.dependencies]
 assert_matches = "1.5.0"
 async-trait = "0.1.89"
-base64 = "0.22.1"
+base64 = "0.23.0"
 bincode = "1.3.3"
 bs58 = "0.5.1"
 candid = "0.10.29"


### PR DESCRIPTION
Consolidates the newly-opened Dependabot bumps that require no source-code changes into a single PR, one commit per bump, so they can run through CI (which needs repository secrets unavailable to Dependabot-authored runs) and be merged together. Follow-up to #367.

Included (manifest and/or lockfile only):
- `candid` 0.10.31 → 0.10.32 (#378)
- `base64` 0.22.1 → 0.23.0 (#377)

Deliberately excluded — these need code or toolchain changes beyond a version bump and are left as their standalone Dependabot PRs:
- `ic-agent` 0.49.2 (#376): `ic-agent-canister-runtime` 0.4.0 pins `ic-agent ^0.47`, so bumping ours pulls in a second `ic_agent` version and breaks the end-to-end tests.
- `solana-client` 4.1.2 (#369), `solana-account-decoder-client-types` 4.1.2 (#368), `solana-transaction-status-client-types` 4.1.2 (#374), `solana-rpc-client-api` 4.1.2 (#373): the Solana 4.x line pulls `solana-streamer` 4.x, which uses an unstable `const` `Duration::from_hours` unavailable on the pinned Rust toolchain; these are also mutually coupled.
- `solana-transaction-error` 3.3.0 (#364): adds a `TransactionError` variant mirrored in the Candid-exposed enum — a public-API change.
- `pocket-ic` 15.0.0 (#363): incompatible with `ic-metrics-assert`/`ic-pocket-canister-runtime` 0.5.0, which pin `pocket-ic` 13.

Verified locally: workspace `clippy` (`-Dwarnings`), `cargo doc` (`--deny warnings`), `--locked` lockfile consistency, and unit tests all pass. (`base64` 0.23.0 coexists with 0.22.1 in the tree because `serde_with` still pins the 0.22 line — same resolution Dependabot's own PR produced.)
