### PR TITLE
build(toolchain): bump Rust to 1.97.1

### DIFF
--- a/libs/types/src/solana/transaction/mod.rs
+++ b/libs/types/src/solana/transaction/mod.rs
@@ -153,8 +153,8 @@ pub struct TransactionStatus {
     /// The slot the transaction was processed.
     pub slot: u64,
     /// *DEPRECATED*: Transaction status:
-    ///  * [`Ok(())`] - Transaction was successful
-    ///  * [`Err(err)`] - Transaction failed with [`TransactionError`] `err`
+    ///  * `Ok(())` - Transaction was successful
+    ///  * `Err(err)` - Transaction failed with [`TransactionError`] `err`
     pub status: Result<(), TransactionError>,
     /// Error if transaction failed, [`None`] if transaction succeeded.
     pub err: Option<TransactionError>,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.90.0"
+channel = "1.97.1"
 components = ["rustfmt", "clippy"]
 targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
## Summary

Bumps the pinned Rust toolchain from 1.90.0 to 1.97.1 (current stable as of July 2026).

`std::iter::chain` (tracked by rust-lang/rust#125964) is now stable in 1.97, which unblocks a future upgrade of `solana-client` to 4.x (previously blocked by `E0658` on that nightly-only feature).

🤖 Generated with [Claude Code](https://claude.com/claude-code)